### PR TITLE
Unify adjusted-peak thresholding into a single source of truth

### DIFF
--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -20,6 +20,7 @@ from displacement_tracker.util.env_loader import load_yaml_with_env
 from displacement_tracker.util.logging_config import setup_logging
 from displacement_tracker.util.distance import interpolate_centroid
 from displacement_tracker.util.deduplication import merge_close_points_global
+from displacement_tracker.util.thresholding import passes_threshold
 from displacement_tracker.util.tiff_predictions import (
     save_prediction_tiff,
     merge_prediction_tiffs,
@@ -33,7 +34,7 @@ NMS_SIGMA_FRACTION = 0.75
 
 def extract_tile_centroids(probs_np, bounds, threshold, min_area, crop_pixels=0):
     """Threshold a tile prediction map and return interpolated region centroids."""
-    mask = probs_np > threshold
+    mask = passes_threshold(probs_np, threshold)
     labeled, num_features = label(mask)
 
     coords = []
@@ -77,7 +78,7 @@ def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, min_area=5, sigma=
         stride=1,
         padding=min_area // 2,
     )
-    local_max_mask = (score_t == max_pooled) & (score_t > threshold)
+    local_max_mask = (score_t == max_pooled) & passes_threshold(score_t, threshold)
 
     rows, cols = torch.where(local_max_mask[0, 0])
     shape = probs_np.shape

--- a/displacement_tracker/h_merge_geojsons.py
+++ b/displacement_tracker/h_merge_geojsons.py
@@ -19,6 +19,7 @@ import yaml
 
 from displacement_tracker.util.deduplication import merge_close_points_global
 from displacement_tracker.util.logging_config import setup_logging
+from displacement_tracker.util.thresholding import filter_points_by_adjusted_peak
 
 LOGGER = setup_logging("merge_geojsons")
 
@@ -244,19 +245,12 @@ def cli(
     for path in geojson_files:
         pts = load_points_from_geojson(path)
         threshold = resolve_threshold(path.name, thresholds_data, min_adj_peak)
-        if threshold > 0.0:
-            filtered = []
-            for p in pts:
-                p[3] = (p[3] - p[2]) * adjustment_factor + p[2]  # Adjusted peak after scaling
-                if p[3] >= threshold:
-                    filtered.append(p)
-            LOGGER.info(
-                "  %s: %d points loaded, %d kept (adj_peak >= %.4f)",
-                path.name, len(pts), len(filtered), threshold,
-            )
-            pts = filtered
-        else:
-            LOGGER.info("  %s: %d points", path.name, len(pts))
+        loaded = len(pts)
+        pts = filter_points_by_adjusted_peak(pts, threshold, adjustment_factor)
+        LOGGER.info(
+            "  %s: %d points loaded, %d kept (adj_peak >= %.4f)",
+            path.name, loaded, len(pts), threshold,
+        )
 
         if exclusion_geom is not None:
             before_exclusion = len(pts)

--- a/displacement_tracker/util/thresholding.py
+++ b/displacement_tracker/util/thresholding.py
@@ -1,0 +1,37 @@
+"""
+Single source of truth for adjusted-peak thresholding.
+
+The prediction flow (e_predict_json), the merge flow (h_merge_geojsons) and the
+validation flow (util/validation_core) must all apply identical semantics:
+
+    rescaled = peak_value + factor * (adjusted_peak - peak_value)
+    keep iff rescaled >= threshold
+"""
+
+
+def rescale_adjusted_peak(peak_value, adjusted_peak, factor):
+    """Rescale the adjusted peak around the raw peak by ``factor``.
+
+    Works elementwise on scalars, numpy arrays, pandas Series and torch tensors.
+    factor=0 collapses to peak_value, factor=1 leaves adjusted_peak unchanged.
+    """
+    return peak_value + factor * (adjusted_peak - peak_value)
+
+
+def passes_threshold(value, threshold):
+    """Keep iff ``value >= threshold``. Works elementwise on arrays/tensors."""
+    return value >= threshold
+
+
+def filter_points_by_adjusted_peak(points, threshold, adjustment_factor=1.0):
+    """Rescale and threshold (lat, lon, peak_value, adjusted_peak) points.
+
+    Returns the kept points with adjusted_peak replaced by its rescaled value,
+    so downstream consumers see the same value that was thresholded.
+    """
+    kept = []
+    for lat, lon, peak, adj_peak in points:
+        rescaled = rescale_adjusted_peak(peak, adj_peak, adjustment_factor)
+        if passes_threshold(rescaled, threshold):
+            kept.append((lat, lon, peak, rescaled))
+    return kept

--- a/displacement_tracker/util/validation_core.py
+++ b/displacement_tracker/util/validation_core.py
@@ -18,6 +18,11 @@ from rasterio import features, mask
 from rasterio.transform import rowcol
 from scipy.stats import spearmanr
 
+from displacement_tracker.util.thresholding import (
+    passes_threshold,
+    rescale_adjusted_peak,
+)
+
 
 # Direction of optimization for each metric: "min" = lower is better.
 METRIC_DIRECTIONS: Dict[str, str] = {
@@ -148,9 +153,10 @@ def keep_mask_from_params(pred_prepped, factor: float, cutoff: float) -> np.ndar
     The rescaled peak is `peak_value + factor * (adjusted_peak - peak_value)`;
     a point is kept iff its rescaled peak is >= `cutoff`.
     """
-    delta = pred_prepped["adjusted_peak"] - pred_prepped["peak_value"]
-    rescaled = pred_prepped["peak_value"] + factor * delta
-    return (rescaled >= cutoff).to_numpy()
+    rescaled = rescale_adjusted_peak(
+        pred_prepped["peak_value"], pred_prepped["adjusted_peak"], factor
+    )
+    return passes_threshold(rescaled, cutoff).to_numpy()
 
 
 def compute_metrics(


### PR DESCRIPTION
## Problem

Three copies of the "rescale adjusted peak + cutoff" logic had drifted apart:

- `h_merge_geojsons.py` — `adj = peak + factor * (adj - peak)`, keep iff `adj >= threshold`, but only when threshold > 0, so `--adjustment-factor` was silently ignored at threshold 0.
- `e_predict_json.py` (NMS) — kept local maxima with strict `score > threshold` (`>` vs `>=` in merge); centroid path likewise used `>`.
- `util/validation_core.py` (`keep_mask_from_params`) — a third, vectorized copy of the same formula.

## Change

New `displacement_tracker/util/thresholding.py` is the single source of truth, following the merge_geojsons semantics:

```
rescaled = peak_value + factor * (adjusted_peak - peak_value)
keep iff rescaled >= threshold
```

All three flows now reference it: `h_merge_geojsons` uses `filter_points_by_adjusted_peak` (which still writes the rescaled value to the output GPKG, as before), `e_predict_json` uses `passes_threshold` in both NMS and centroid masks, and `validation_core.keep_mask_from_params` delegates to `rescale_adjusted_peak` + `passes_threshold`.

## Behaviour changes

- NMS/centroid extraction keeps points exactly at the threshold (`>=` instead of `>`) — negligible on continuous scores.
- `merge-geojsons --adjustment-factor` is now applied even when the effective threshold is 0.

## Testing

Unit-checked the shared module (`>=` boundary, rescaling around peak, factor applied at threshold 0); `py_compile` on all touched files. Full pipeline not run (no environment with torch/geopandas on this machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)