### PR TITLE
Fix NMS shape mismatch for even suppression windows; split min_area per selection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Recommended selection parameters:
 selection:
   threshold: 0.0001
   factor: 1.0
-  min_area: 7
+  nms_kernel_size: 7
   min_distance_m: 3.0
 ```
 

--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -71,11 +71,21 @@ def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, min_area=5, sigma=
     blurred_t = torch.as_tensor(blurred_np, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
     score_t = probs_t + blurred_t * factor
 
-    max_pooled = torch.nn.functional.max_pool2d(
+    # Pad manually so the pooled map always matches score_t's shape: max_pool2d's
+    # built-in symmetric padding of min_area // 2 only preserves the shape for odd
+    # kernel sizes, producing an off-by-one dimensionality mismatch for even ones.
+    kernel_size = int(min_area)
+    pad_before = (kernel_size - 1) // 2
+    pad_after = kernel_size - 1 - pad_before
+    padded_score_t = torch.nn.functional.pad(
         score_t,
-        kernel_size=min_area,
+        (pad_before, pad_after, pad_before, pad_after),
+        value=float("-inf"),
+    )
+    max_pooled = torch.nn.functional.max_pool2d(
+        padded_score_t,
+        kernel_size=kernel_size,
         stride=1,
-        padding=min_area // 2,
     )
     local_max_mask = (score_t == max_pooled) & (score_t > threshold)
 

--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -152,6 +152,13 @@ def predict(
             "selection.method must be one of: 'centroid', 'nms'"
         )
 
+    if method == "nms" and "min_area" in selection_cfg:
+        raise click.ClickException(
+            "selection.min_area has been migrated to selection.nms_kernel_size for the "
+            "'nms' method (default 7); rename the key in your config. selection.min_area "
+            "now only applies to the 'centroid' method."
+        )
+
     if sample_cfg and sample_cfg.get("enable", True):
         total = len(dataset)
         size = min(sample_cfg.get("size", total), total)

--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -64,7 +64,7 @@ def extract_tile_centroids(probs_np, bounds, threshold, min_area, crop_pixels=0)
     return coords
 
 
-def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, min_area=5, sigma=50.0, crop_pixels=0):
+def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, kernel_size=7, sigma=50.0, crop_pixels=0):
     """Return interpolated local maxima (lat, lon, peak_value) above threshold."""
     probs_t = torch.as_tensor(probs_np, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
     blurred_np = gaussian_filter(probs_np, sigma=sigma)
@@ -72,9 +72,9 @@ def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, min_area=5, sigma=
     score_t = probs_t + blurred_t * factor
 
     # Pad manually so the pooled map always matches score_t's shape: max_pool2d's
-    # built-in symmetric padding of min_area // 2 only preserves the shape for odd
-    # kernel sizes, producing an off-by-one dimensionality mismatch for even ones.
-    kernel_size = int(min_area)
+    # built-in symmetric padding of kernel_size // 2 only preserves the shape for
+    # odd kernel sizes, producing an off-by-one dimensionality mismatch for even ones.
+    kernel_size = int(kernel_size)
     pad_before = (kernel_size - 1) // 2
     pad_after = kernel_size - 1 - pad_before
     padded_score_t = torch.nn.functional.pad(
@@ -132,15 +132,17 @@ def predict(
     Streaming: write per-tile centroids to a tmp NDJSON to avoid accumulating Python objects.
     """
     threshold = selection_cfg.get("threshold", 0.5)
-    min_area = selection_cfg.get("min_area", 20)
+    min_area = selection_cfg.get("min_area", 20)  # centroid method only
+    nms_kernel_size = selection_cfg.get("nms_kernel_size", 7)  # nms method only
     crop_pixels = selection_cfg.get("crop_pixels", 0)
     nms_sigma = selection_cfg.get("nms_sigma", 50.0)
     agreement = selection_cfg.get("agreement", False)
     min_distance_m = selection_cfg.get("min_distance_m", 2.0)
     factor = selection_cfg.get("factor", 0.0)
     LOGGER.info(f"🔹 Prediction selection parameters: method={selection_cfg.get('method', 'centroid')}, "
-        f"threshold={threshold}, min_area={min_area}, crop_pixels={crop_pixels}, "
-        f"nms_sigma={nms_sigma}, agreement={agreement}, min_distance_m={min_distance_m}, factor={factor}"
+        f"threshold={threshold}, min_area={min_area}, nms_kernel_size={nms_kernel_size}, "
+        f"crop_pixels={crop_pixels}, nms_sigma={nms_sigma}, agreement={agreement}, "
+        f"min_distance_m={min_distance_m}, factor={factor}"
     )
     method = str(selection_cfg.get("method", "centroid")).strip().lower()
     batch_size = max(1, int(batch_size))
@@ -252,7 +254,7 @@ def predict(
 
                             if method == "nms":
                                 coords = extract_tile_nms(
-                                    probs_np, bounds, threshold, factor=factor, min_area=min_area, sigma=nms_sigma, crop_pixels=crop_pixels
+                                    probs_np, bounds, threshold, factor=factor, kernel_size=nms_kernel_size, sigma=nms_sigma, crop_pixels=crop_pixels
                                 )
                             else:
                                 coords = extract_tile_centroids(

--- a/predict_config.yaml
+++ b/predict_config.yaml
@@ -34,7 +34,7 @@ prediction:
     agreement: false
     threshold: 0.0001
     factor: 1.0
-    min_area: 7
+    nms_kernel_size: 7
     min_distance_m: 3.0
     # crop_pixels and nms_sigma are derived from processing.margin_metres
   validation_tifs: false # ideally set to false if sampling is false


### PR DESCRIPTION
## Problem

Setting `prediction.selection.min_area` to an even value crashes the `predict_json` flow when `selection.method: nms` is used:

```
RuntimeError: The size of tensor a (256) must match the size of tensor b (257) at non-singleton dimension 3
```

The root cause is in `extract_tile_nms`, which computed the local-maximum map with:

```python
max_pooled = torch.nn.functional.max_pool2d(
    score_t, kernel_size=min_area, stride=1, padding=min_area // 2
)
```

With stride 1, the output height is `H + 2*(min_area // 2) - min_area + 1`. That equals `H` only when `min_area` is **odd**; for even values the pooled map comes out one pixel larger than the score map, so the mask comparison `(score_t == max_pooled)` fails with the dimensionality mismatch above. The example config's `min_area: 7` masked the bug — and notably, omitting the key entirely would also have crashed, since the config-level fallback in `predict()` was 20 (even).

## Fix

**Shape mismatch:** Pad the score map explicitly with `-inf` (matching `max_pool2d`'s implicit padding semantics), splitting the total `kernel_size - 1` padding asymmetrically across each side, then pool without built-in padding. The pooled output now matches the input shape for any kernel size. For odd values the result is bit-identical to the previous implementation (verified numerically for kernels 1–21).

**Parameter split:** `min_area` previously did double duty across the two selection methods while meaning different things — a labeled-region area filter for `centroid`, but a max-pool suppression window for `nms` — and the defaults were inconsistent (config fallback 20, unused NMS signature default 5, example config 7). The two are now separate:

- `selection.min_area` (default 20) applies to the `centroid` method only, unchanged.
- `selection.nms_kernel_size` (default 7, both in the config lookup and the `extract_tile_nms` signature) is the new name for the NMS suppression window, matching the existing `nms_sigma` naming.

**Config migration guard:** a config that still sets `selection.min_area` together with `method: nms` now fails deliberately with a `ClickException` explaining that the key has been migrated to `selection.nms_kernel_size`, rather than silently running with the new default. `min_area` remains valid for the `centroid` method.

`predict_config.yaml` and the README's recommended selection parameters are updated to the new key.

## Testing

No test suite exists in the repo, so verification was done by exercising the code directly:

- `extract_tile_nms` on random 256×256 probability maps for kernel sizes {4, 6, 7, 8, 20}: all run without error, odd-kernel outputs asserted equal to the old implementation's, new signature default asserted to be 7.
- Migration guard: `nms` + `min_area` raises the migration `ClickException`; `nms` + `nms_kernel_size` and `centroid` + `min_area` pass validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CodbMTDLpvzNciyaYWFVLY