### PR TITLE
Require nits-only approval bar for thermo-nuclear review skill

### DIFF
--- a/.claude/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/.claude/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -171,7 +171,16 @@ Prefer a smaller number of high-conviction comments over a long list of cosmetic
 ## Approval Bar
 
 Do not approve merely because behavior seems correct.
-The bar for approval is:
+
+**Approve only if the only remaining fixes are nits.** A nit is a cosmetic,
+take-it-or-leave-it suggestion — naming preferences, comment wording, trivial
+style choices — that the author could reasonably ignore without leaving the
+codebase worse off. If any remaining finding is more than a nit — anything
+structural, architectural, or maintainability-relevant that you genuinely want
+fixed before merge — the verdict is CHANGES REQUIRED, not an approval with
+caveats. Never downgrade a real finding to a nit in order to approve.
+
+In addition, the bar for approval is:
 
 - no clear structural regression
 - no obvious missed opportunity to make the implementation dramatically simpler when such a path is visible
@@ -191,4 +200,7 @@ Treat these as presumptive blockers unless the author can justify them clearly:
 - the PR adds an unnecessary abstraction, wrapper, or cast-heavy contract that makes the design more indirect
 - the PR duplicates an existing helper or puts logic in the wrong layer when there is a clear canonical home
 
-If those conditions are not met, leave explicit, actionable feedback and push for a cleaner decomposition.
+If those conditions are not met — or any remaining finding rises above nit
+level — do not approve. Leave explicit, actionable feedback and push for a
+cleaner decomposition, and clearly separate blocking findings from nits so
+the author knows exactly what stands between the PR and approval.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -79,7 +79,8 @@ jobs:
             **Thermo-Nuclear Verdict:** APPROVED
             **Thermo-Nuclear Verdict:** CHANGES REQUIRED
 
-            Use APPROVED only if the PR clears the skill's approval bar.
+            Use APPROVED only if the PR clears the skill's approval bar —
+            that is, only if the only remaining fixes are nits.
           claude_args: |
             --model claude-fable-5
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Tightens the thermo-nuclear code quality review skill so it only approves a PR when the only remaining fixes are nits.

- **`.claude/skills/thermo-nuclear-code-quality-review/SKILL.md`** — the Approval Bar now leads with an explicit rule: approve only if every remaining finding is a nit (a cosmetic, take-it-or-leave-it suggestion the author could reasonably ignore). Any structural, architectural, or maintainability-relevant finding means CHANGES REQUIRED rather than an approval with caveats, and the reviewer is told never to downgrade a real finding to a nit to enable approval. The closing instruction also asks the reviewer to separate blocking findings from nits so the author knows exactly what stands between the PR and approval.
- **`.github/workflows/claude-code-review.yml`** — the review prompt restates the same rule where the APPROVED/CHANGES REQUIRED verdict line is decided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CX7LZxwCqHH3m7rVDwbQUy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CX7LZxwCqHH3m7rVDwbQUy)_