### PR TITLE
ci: gate review workflow on an ALLOWED_BASES list

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,7 +3,7 @@ name: Claude Thermo-Nuclear Code Review
 # Manual-only review to avoid unnecessary token spend:
 #   - Comment "@claude review" on a PR when it's ready for review, OR
 #   - Run the workflow manually from the Actions tab with a PR number.
-# Only PRs targeting `main` are reviewed.
+# Only PRs whose base branch is in ALLOWED_BASES are reviewed.
 #
 # Requires the ANTHROPIC_API_KEY repository secret to be set.
 
@@ -16,6 +16,11 @@ on:
         description: "Pull request number to review"
         required: true
         type: string
+
+env:
+  # Space-separated list of base branches eligible for review. Add a branch
+  # here (in one place) to allow reviewing PRs that target it.
+  ALLOWED_BASES: "main Karim"
 
 jobs:
   claude-review:
@@ -38,19 +43,29 @@ jobs:
           base=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json baseRefName --jq .baseRefName)
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "base=$base" >> "$GITHUB_OUTPUT"
-          if [ "$base" != "main" ] && [ "$base" != "Karim" ]; then
-            echo "PR #$PR_NUMBER targets '$base', not 'main' — skipping review."
+
+          allowed=false
+          for b in $ALLOWED_BASES; do
+            if [ "$base" = "$b" ]; then
+              allowed=true
+              break
+            fi
+          done
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+
+          if [ "$allowed" != "true" ]; then
+            echo "PR #$PR_NUMBER targets '$base', which is not in ALLOWED_BASES ($ALLOWED_BASES) — skipping review."
           fi
 
       - name: Checkout PR merge result
-        if: steps.pr.outputs.base == 'main'
+        if: steps.pr.outputs.allowed == 'true'
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ steps.pr.outputs.number }}/merge
           fetch-depth: 0
 
       - name: Run thermo-nuclear code review
-        if: steps.pr.outputs.base == 'main'
+        if: steps.pr.outputs.allowed == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## What

The thermo-nuclear review workflow (`.github/workflows/claude-code-review.yml`) hard-coded `main` as the only reviewable base branch in **three** places:

- the base-check echo (`if [ "$base" != "main" ]`)
- `Checkout PR merge result` → `if: steps.pr.outputs.base == 'main'`
- `Run thermo-nuclear code review` → `if: steps.pr.outputs.base == 'main'`

Because `issue_comment`-triggered workflows always run the file from the default branch, and these two step-level gates require `main`, an `@claude review` comment on a PR targeting any other branch runs the base-check job but **silently skips the checkout and review steps** — no verdict is ever posted.

## Change

Replace the three literals with a single space-separated `ALLOWED_BASES` env list plus an `allowed` step output; both steps now gate on `steps.pr.outputs.allowed == 'true'`. Enabling a new base branch becomes a one-line edit to `ALLOWED_BASES` in one place instead of three scattered `== 'main'` checks.

Currently allows `main` and `Karim` (the latter so the stacked evaluation-pipeline PR #28, which targets `Karim`, can be reviewed).

## Notes

- Behavior for `main`-based PRs is unchanged.
- No change to the trigger conditions, permissions, or the review prompt.
- YAML validated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjFy5GC8fK74DeV5mcEtBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjFy5GC8fK74DeV5mcEtBc)_