### PR TITLE
ci: only set track_progress for the comment-triggered review path

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -69,7 +69,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          track_progress: true
+          # track_progress renders a live checklist comment, but the action
+          # only supports it for PR/issue/comment events — not
+          # workflow_dispatch. Enable it only for the comment path so the
+          # manual-dispatch path (Actions tab / API) works too. The verdict
+          # summary is posted via `gh pr comment` either way.
+          track_progress: ${{ github.event_name == 'issue_comment' }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## What

Follow-up to #32. That PR merged the `ALLOWED_BASES` change, but this one-line fix landed on the branch *after* #32 was already merged, so it never made it to `main`.

`track_progress: true` is hard-coded on the review step. The `claude-code-action` **rejects `track_progress` for `workflow_dispatch` events** — it only supports it for `pull_request`, `issues`, `issue_comment`, and `pull_request_review*`. So the "Run the workflow manually from the Actions tab with a PR number" path advertised in this workflow's own header fails instantly:

```
Action failed with error: track_progress is only supported for events:
pull_request, issues, issue_comment, ... Current event: workflow_dispatch
```

(Observed on a real dispatch run: the base-check and checkout steps succeeded, then the review step died in ~3s before doing anything.)

## Change

Gate it on the event: `track_progress: ${{ github.event_name == 'issue_comment' }}`. The comment-triggered path keeps its live checklist; the manual-dispatch path no longer errors. The verdict summary is posted via `gh pr comment` in both cases, so dispatch runs still post their result.

## Notes

- Behavior for the normal `@claude review` comment path is unchanged.
- YAML validated locally; verified on a live dispatch that the fixed workflow reaches and completes the review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjFy5GC8fK74DeV5mcEtBc

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjFy5GC8fK74DeV5mcEtBc)_