### PR TITLE
Add scope-creep guard and user escalation to bomb-proof skill

### DIFF
--- a/.claude/skills/bomb-proof/SKILL.md
+++ b/.claude/skills/bomb-proof/SKILL.md
@@ -12,8 +12,9 @@ push, and re-trigger — repeating until approved or a round cap is hit.
 
 ## Prerequisites
 
-- An open PR **targeting `main`** (the review workflow silently skips other
-  base branches — do not loop on a PR with a different base).
+- An open PR **targeting a base branch the review workflow allows** (see
+  `ALLOWED_BASES` in the workflow file; it silently skips other base
+  branches — do not loop on a PR with a different base).
 - The PR branch checked out locally with push access, so findings can be fixed.
 - `gh` CLI (or equivalent GitHub MCP tools) authenticated for this repository.
 - The repository's `ANTHROPIC_API_KEY` secret configured (the workflow fails
@@ -77,10 +78,29 @@ issues first, nits last). The reviewer applies the
 simplification, not cosmetic tweaks — actually restructure; do not paper over
 findings with comments or minimal edits, and do not game the verdict.
 
-If a finding is genuinely wrong or out of scope for the PR, reply to that
-comment explaining why instead of implementing it — but be honest: the bar
-for disagreeing with the reviewer is high, and repeated disagreement is a
-signal to escalate to the user, not to keep looping.
+**Guard the PR's scope.** The reviewer is deliberately harsh and will
+sometimes ask for work this PR should not carry. Before implementing a
+finding, decide whether it actually belongs here:
+
+- **In scope:** problems in code the PR added or changed, and structure the
+  change itself made worse.
+- **Scope creep:** rework of pre-existing code the PR barely touches,
+  codebase-wide restructurings, or "while you're here" improvements that are
+  not needed for this change to land cleanly.
+
+Push back on scope creep and on unreasonable asks (demands disproportionate
+to the size of the change, speculative abstractions, rewrites of working
+code the PR didn't cause): reply to the finding explaining why it doesn't
+belong in this PR, and suggest a follow-up issue or PR when the underlying
+point has merit. Do not implement out-of-scope work just to win approval —
+but be honest in the other direction too: do not label a legitimate finding
+about your own change "scope creep" to dodge the work.
+
+**Fall back to the user's judgement on conflict.** If the reviewer re-raises
+a finding you pushed back on, or you are genuinely unsure whether an ask is
+reasonable, stop and put the question to the user with both positions laid
+out — their call decides whether the finding gets implemented, deferred to a
+follow-up, or dropped. Do not burn rounds arguing with the reviewer.
 
 Verify the code still works (tests, linters, whatever the repo provides),
 commit with a clear message, and push to the PR branch.
@@ -99,3 +119,6 @@ Go back to step 1 for the next round.
 - **Non-converging review** (same findings re-raised after honest fix
   attempts, or contradictory demands between rounds) — stop and escalate to
   the user with both positions laid out.
+- **Scope conflict** — the reviewer insists on a finding you judged
+  out-of-scope or unreasonable. Stop and escalate to the user; do not
+  implement it to force approval, and do not keep looping around it.


### PR DESCRIPTION
## Summary

Follow-up to #31. Updates the bomb-proof skill so the agent driving the review loop guards the PR's scope instead of implementing everything the reviewer demands.

- **Scope-creep guard in step 4** — before implementing a finding, the agent classifies it: in scope (problems in code the PR added or changed, or structure the change made worse) vs. scope creep (rework of barely-touched pre-existing code, codebase-wide restructurings, "while you're here" improvements). It pushes back on scope creep and unreasonable asks by replying to the finding and suggesting a follow-up where the point has merit — while being explicitly forbidden from labeling legitimate findings about its own change "scope creep" to dodge work.
- **User judgement as the fallback** — if the reviewer re-raises a finding the agent pushed back on, or the agent is unsure whether an ask is reasonable, it stops and puts the question to the user with both positions laid out rather than burning rounds arguing.
- **New "Scope conflict" exit condition** — a reviewer insisting on an out-of-scope finding ends the loop with escalation, never with the agent implementing it to force approval.
- **Prerequisite wording** — the base-branch prerequisite now references the workflow's configurable `ALLOWED_BASES` list instead of hardcoding `main`, matching the current workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CX7LZxwCqHH3m7rVDwbQUy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CX7LZxwCqHH3m7rVDwbQUy)_