### PR TITLE
Fix ruff findings, format the source tree, and add PR CI for lint

### DIFF
--- a/.github/allowed-bases.txt
+++ b/.github/allowed-bases.txt
@@ -1,0 +1,6 @@
+# Base branches whose PRs get CI (tests + ruff) and are eligible for the
+# thermo-nuclear review workflow. One branch per line; lines starting
+# with # are ignored. This file is the single source of truth — edit it
+# here to allow a new base branch in both workflows.
+main
+Karim

--- a/.github/allowed-bases.txt
+++ b/.github/allowed-bases.txt
@@ -1,6 +1,0 @@
-# Base branches whose PRs get CI (tests + ruff) and are eligible for the
-# thermo-nuclear review workflow. One branch per line; lines starting
-# with # are ignored. This file is the single source of truth — edit it
-# here to allow a new base branch in both workflows.
-main
-Karim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,12 @@ name: CI
 # Runs on PRs into the base branches listed in .github/allowed-bases.txt
 # (shared with the review workflow). Trigger filters are static YAML, so
 # the workflow fires for every PR and a cheap gate job decides from the
-# shared list whether the real jobs run.
+# shared list whether the real jobs run. Jobs skipped this way still count
+# as passing for branch protection.
+#
+# The gate reads the copy of allowed-bases.txt on the PR's own merge ref,
+# whereas the review workflow reads the default-branch copy; see the note
+# in claude-code-review.yml for why they can briefly disagree.
 on:
   pull_request:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,47 +1,15 @@
 name: CI
 
-# Runs on PRs into the base branches listed in .github/allowed-bases.txt
-# (shared with the review workflow). Trigger filters are static YAML, so
-# the workflow fires for every PR and a cheap gate job decides from the
-# shared list whether the real jobs run. Jobs skipped this way still count
-# as passing for branch protection.
-#
-# The gate reads the copy of allowed-bases.txt on the PR's own merge ref,
-# whereas the review workflow reads the default-branch copy; see the note
-# in claude-code-review.yml for why they can briefly disagree.
+# Keep the base-branch list here in step with ALLOWED_BASES in
+# claude-code-review.yml — two short static lists beat the machinery it
+# would take to share one.
 on:
   pull_request:
+    branches: [main, Karim]
 
 jobs:
-  gate:
-    name: Check base branch
-    runs-on: ubuntu-latest
-    outputs:
-      allowed: ${{ steps.check.outputs.allowed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/allowed-bases.txt
-          sparse-checkout-cone-mode: false
-
-      - name: Compare base branch against allowed-bases.txt
-        id: check
-        run: |
-          base="$GITHUB_BASE_REF"
-          allowed=false
-          for b in $(grep -v '^#' .github/allowed-bases.txt); do
-            if [ "$base" = "$b" ]; then
-              allowed=true
-              break
-            fi
-          done
-          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
-          echo "PR base branch '$base': allowed=$allowed"
-
   lint:
     name: Lint & format (ruff)
-    needs: gate
-    if: needs.gate.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+# Runs on PRs into the base branches listed in .github/allowed-bases.txt
+# (shared with the review workflow). Trigger filters are static YAML, so
+# the workflow fires for every PR and a cheap gate job decides from the
+# shared list whether the real jobs run.
+on:
+  pull_request:
+
+jobs:
+  gate:
+    name: Check base branch
+    runs-on: ubuntu-latest
+    outputs:
+      allowed: ${{ steps.check.outputs.allowed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/allowed-bases.txt
+          sparse-checkout-cone-mode: false
+
+      - name: Compare base branch against allowed-bases.txt
+        id: check
+        run: |
+          base="$GITHUB_BASE_REF"
+          allowed=false
+          for b in $(grep -v '^#' .github/allowed-bases.txt); do
+            if [ "$base" = "$b" ]; then
+              allowed=true
+              break
+            fi
+          done
+          echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
+          echo "PR base branch '$base': allowed=$allowed"
+
+  lint:
+    name: Lint & format (ruff)
+    needs: gate
+    if: needs.gate.outputs.allowed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Same constraint as the dev dependency group in pyproject.toml
+      - name: Install ruff
+        run: pip install "ruff>=0.15.0,<0.16.0"
+
+      - name: Lint
+        run: ruff check .
+
+      - name: Check formatting
+        run: ruff format --check .

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,14 @@ name: Claude Thermo-Nuclear Code Review
 # Only PRs whose base branch is in .github/allowed-bases.txt (shared with
 # the CI workflow) are reviewed.
 #
+# Note the deliberate asymmetry in how the two workflows read that shared
+# file: CI runs per-PR and reads the copy on the PR's own merge ref, while
+# this workflow reads the copy on the default branch (it is triggered by a
+# comment, which carries no PR checkout). So a PR that itself edits
+# allowed-bases.txt enables CI for itself but not review, until it merges.
+# Neither gate protects a secret — this only decides whether a job runs —
+# so the divergence is a known property rather than a hole.
+#
 # Requires the ANTHROPIC_API_KEY repository secret to be set.
 
 on:
@@ -19,8 +27,10 @@ on:
         type: string
 
 env:
-  # Space-separated fallback used only until .github/allowed-bases.txt
-  # (the single source of truth, read from the default branch) exists there.
+  # TRANSITIONAL — delete this and the `gh api` fallback below once
+  # .github/allowed-bases.txt exists on the default branch (it arrives
+  # there when the branch carrying it merges). Until then this workflow
+  # has no shared file to read and would refuse every PR.
   ALLOWED_BASES_FALLBACK: "main Karim"
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,16 +3,7 @@ name: Claude Thermo-Nuclear Code Review
 # Manual-only review to avoid unnecessary token spend:
 #   - Comment "@claude review" on a PR when it's ready for review, OR
 #   - Run the workflow manually from the Actions tab with a PR number.
-# Only PRs whose base branch is in .github/allowed-bases.txt (shared with
-# the CI workflow) are reviewed.
-#
-# Note the deliberate asymmetry in how the two workflows read that shared
-# file: CI runs per-PR and reads the copy on the PR's own merge ref, while
-# this workflow reads the copy on the default branch (it is triggered by a
-# comment, which carries no PR checkout). So a PR that itself edits
-# allowed-bases.txt enables CI for itself but not review, until it merges.
-# Neither gate protects a secret — this only decides whether a job runs —
-# so the divergence is a known property rather than a hole.
+# Only PRs whose base branch is in ALLOWED_BASES are reviewed.
 #
 # Requires the ANTHROPIC_API_KEY repository secret to be set.
 
@@ -27,11 +18,9 @@ on:
         type: string
 
 env:
-  # TRANSITIONAL — delete this and the `gh api` fallback below once
-  # .github/allowed-bases.txt exists on the default branch (it arrives
-  # there when the branch carrying it merges). Until then this workflow
-  # has no shared file to read and would refuse every PR.
-  ALLOWED_BASES_FALLBACK: "main Karim"
+  # Space-separated list of base branches eligible for review. Add a branch
+  # here (in one place) to allow reviewing PRs that target it.
+  ALLOWED_BASES: "main Karim"
 
 jobs:
   claude-review:
@@ -55,19 +44,8 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
-          # Allowed bases come from .github/allowed-bases.txt on the default
-          # branch (shared with the CI workflow); fall back to the env list
-          # until the file lands there.
-          allowed_bases=""
-          if content=$(gh api "repos/$GITHUB_REPOSITORY/contents/.github/allowed-bases.txt" --jq .content 2>/dev/null); then
-            allowed_bases=$(printf '%s' "$content" | base64 -d | grep -v '^#' | xargs)
-          fi
-          if [ -z "$allowed_bases" ]; then
-            allowed_bases="$ALLOWED_BASES_FALLBACK"
-          fi
-
           allowed=false
-          for b in $allowed_bases; do
+          for b in $ALLOWED_BASES; do
             if [ "$base" = "$b" ]; then
               allowed=true
               break
@@ -76,7 +54,7 @@ jobs:
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
 
           if [ "$allowed" != "true" ]; then
-            echo "PR #$PR_NUMBER targets '$base', which is not in the allowed bases ($allowed_bases) — skipping review."
+            echo "PR #$PR_NUMBER targets '$base', which is not in ALLOWED_BASES ($ALLOWED_BASES) — skipping review."
           fi
 
       - name: Checkout PR merge result

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,7 +3,8 @@ name: Claude Thermo-Nuclear Code Review
 # Manual-only review to avoid unnecessary token spend:
 #   - Comment "@claude review" on a PR when it's ready for review, OR
 #   - Run the workflow manually from the Actions tab with a PR number.
-# Only PRs whose base branch is in ALLOWED_BASES are reviewed.
+# Only PRs whose base branch is in .github/allowed-bases.txt (shared with
+# the CI workflow) are reviewed.
 #
 # Requires the ANTHROPIC_API_KEY repository secret to be set.
 
@@ -18,9 +19,9 @@ on:
         type: string
 
 env:
-  # Space-separated list of base branches eligible for review. Add a branch
-  # here (in one place) to allow reviewing PRs that target it.
-  ALLOWED_BASES: "main Karim"
+  # Space-separated fallback used only until .github/allowed-bases.txt
+  # (the single source of truth, read from the default branch) exists there.
+  ALLOWED_BASES_FALLBACK: "main Karim"
 
 jobs:
   claude-review:
@@ -44,8 +45,19 @@ jobs:
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
+          # Allowed bases come from .github/allowed-bases.txt on the default
+          # branch (shared with the CI workflow); fall back to the env list
+          # until the file lands there.
+          allowed_bases=""
+          if content=$(gh api "repos/$GITHUB_REPOSITORY/contents/.github/allowed-bases.txt" --jq .content 2>/dev/null); then
+            allowed_bases=$(printf '%s' "$content" | base64 -d | grep -v '^#' | xargs)
+          fi
+          if [ -z "$allowed_bases" ]; then
+            allowed_bases="$ALLOWED_BASES_FALLBACK"
+          fi
+
           allowed=false
-          for b in $ALLOWED_BASES; do
+          for b in $allowed_bases; do
             if [ "$base" = "$b" ]; then
               allowed=true
               break
@@ -54,7 +66,7 @@ jobs:
           echo "allowed=$allowed" >> "$GITHUB_OUTPUT"
 
           if [ "$allowed" != "true" ]; then
-            echo "PR #$PR_NUMBER targets '$base', which is not in ALLOWED_BASES ($ALLOWED_BASES) — skipping review."
+            echo "PR #$PR_NUMBER targets '$base', which is not in the allowed bases ($allowed_bases) — skipping review."
           fi
 
       - name: Checkout PR merge result

--- a/displacement_tracker/b1_annotated_scanner.py
+++ b/displacement_tracker/b1_annotated_scanner.py
@@ -5,6 +5,7 @@ JSON containing the date-filtered tent features. The runtime dataset reads
 tiles from the standardised raster on demand and rasterises labels via
 `create_label_from_feats(...)` against the JSON-stored feature list.
 """
+
 from __future__ import annotations
 
 import json
@@ -64,9 +65,7 @@ def _build_row(
     labels_path: str,
     is_complete: bool,
 ) -> dict[str, Any]:
-    feature_ids = [
-        int(f["_idx"]) for f in feats if isinstance(f, dict) and "_idx" in f
-    ]
+    feature_ids = [int(f["_idx"]) for f in feats if isinstance(f, dict) and "_idx" in f]
     return {
         "tile_id": compute_tile_id(raster_path, tile.r0, tile.c0),
         "raster_path": raster_path,
@@ -170,16 +169,12 @@ def _scan_grouped_tiles(
 ) -> int:
     span_m = core_m + 2.0 * margin_m
     processed_count = 0
-    for (i, j), feats in tqdm(
-        grouped.items(), desc=f"{base_name} processing tiles"
-    ):
+    for (i, j), feats in tqdm(grouped.items(), desc=f"{base_name} processing tiles"):
         if not feats:
             continue
         x_centre = i * core_m
         y_centre = j * core_m
-        tile = compute_tile_window(
-            src, x_centre, y_centre, core_m, margin_m, min_valid
-        )
+        tile = compute_tile_window(src, x_centre, y_centre, core_m, margin_m, min_valid)
         if tile is None:
             continue
         if prewar_src is not None:
@@ -236,9 +231,7 @@ def scan_grouped_coordinates(
     wgs84_to_src = Transformer.from_crs("EPSG:4326", src.crs, always_xy=True)
 
     src_means, src_stds = compute_standardisation_stats(src)
-    manifest_writer.set_raster_stats(
-        src.name, src_means, src_stds, nodata=src.nodata
-    )
+    manifest_writer.set_raster_stats(src.name, src_means, src_stds, nodata=src.nodata)
 
     prewar_src = open_raster(prewar_path) if prewar_path else None
     if prewar_src is not None:
@@ -313,9 +306,7 @@ def scan_grouped_coordinates(
         LOGGER.info(
             f"[{base_name}] marked as INCOMPLETE - applying quality gating from YAML."
         )
-        LOGGER.info(
-            f"[{base_name}] Found {len(grouped)} coordinate groups with tents."
-        )
+        LOGGER.info(f"[{base_name}] Found {len(grouped)} coordinate groups with tents.")
         LOGGER.info(
             f"GeoTIFF bounds: min_lon={src.bounds.left}, min_lat={src.bounds.bottom}, max_lon={src.bounds.right}, max_lat={src.bounds.top}"
         )

--- a/displacement_tracker/b2_image_scanner.py
+++ b/displacement_tracker/b2_image_scanner.py
@@ -5,6 +5,7 @@ process aggregates rows and writes a single Parquet manifest at end-of-TIFF.
 The HDF5 materialisation step is gone — the runtime dataset reads tiles
 directly from the standardised raster.
 """
+
 from __future__ import annotations
 
 import inspect
@@ -121,9 +122,10 @@ def _chunked(seq: Iterable, n: int) -> Iterator[list]:
 def _supports_max_tasks_per_child() -> bool:
     """ProcessPoolExecutor.max_tasks_per_child was added in Python 3.11."""
     try:
-        return "max_tasks_per_child" in inspect.signature(
-            ProcessPoolExecutor.__init__
-        ).parameters
+        return (
+            "max_tasks_per_child"
+            in inspect.signature(ProcessPoolExecutor.__init__).parameters
+        )
     except (TypeError, ValueError):
         return sys.version_info >= (3, 11)
 
@@ -168,9 +170,7 @@ def scan_all_coordinates(
         return
 
     src_means, src_stds = compute_standardisation_stats(src)
-    manifest_writer.set_raster_stats(
-        src.name, src_means, src_stds, nodata=src.nodata
-    )
+    manifest_writer.set_raster_stats(src.name, src_means, src_stds, nodata=src.nodata)
 
     bounds = src.bounds
     LOGGER.info(

--- a/displacement_tracker/b_coordinate_scanner.py
+++ b/displacement_tracker/b_coordinate_scanner.py
@@ -180,7 +180,7 @@ def _read_rgb(src: rasterio.io.DatasetReader, window):
     if data.size == 0 or np.all(np.isnan(data)) or np.all(data == 0):
         return None
     return data.astype(np.float32)
-    
+
 
 def _create_label_from_feats(
     lon_min: float,
@@ -351,15 +351,16 @@ def process_group(
                                     nodata_pre = prewar_src.nodata
                                     if nodata_pre is not None:
                                         valid_mask = (~np.isnan(prewar_tile_rgb)) & (
-                                                prewar_tile_rgb != nodata_pre
+                                            prewar_tile_rgb != nodata_pre
                                         )
                                     else:
                                         valid_mask = (~np.isnan(prewar_tile_rgb)) & (
-                                                prewar_tile_rgb != 0
+                                            prewar_tile_rgb != 0
                                         )
 
                                     valid_fraction_pre = (
-                                            np.count_nonzero(valid_mask) / prewar_tile_rgb.size
+                                        np.count_nonzero(valid_mask)
+                                        / prewar_tile_rgb.size
                                     )
                                 except Exception:
                                     valid_fraction_pre = 0.0
@@ -368,11 +369,15 @@ def process_group(
                                     prewar_tile_rgb = None
                                 else:
                                     # --- per-tile, per-channel standardisation ---
-                                    mean = prewar_tile_rgb.mean(axis=(1, 2), keepdims=True)
-                                    std = prewar_tile_rgb.std(axis=(1, 2), keepdims=True)
-                                    prewar_tile_rgb = (
-                                                              prewar_tile_rgb - mean
-                                                      ) / (std + 1e-6)
+                                    mean = prewar_tile_rgb.mean(
+                                        axis=(1, 2), keepdims=True
+                                    )
+                                    std = prewar_tile_rgb.std(
+                                        axis=(1, 2), keepdims=True
+                                    )
+                                    prewar_tile_rgb = (prewar_tile_rgb - mean) / (
+                                        std + 1e-6
+                                    )
 
                         except Exception:
                             prewar_tile_rgb = None
@@ -383,7 +388,12 @@ def process_group(
         h = rgb.shape[1]
         w = rgb.shape[2]
         if prewar_tile_rgb is None:
-            return None, None, None, None # Previously this allowed for training tiles without prewar data
+            return (
+                None,
+                None,
+                None,
+                None,
+            )  # Previously this allowed for training tiles without prewar data
         else:
             ph, pw = prewar_tile_rgb.shape[1], prewar_tile_rgb.shape[2]
             if (ph, pw) != (h, w):
@@ -412,7 +422,7 @@ def is_high_quality_tile(
     start_threshold: float,
     max_missing_end: float,
     min_valid_fraction: float,
-    transformer
+    transformer,
 ) -> bool:
     """
     Checks date distributions and raster valid-pixel fraction for the tile.
@@ -483,9 +493,8 @@ class HDF5Writer:
         self._d_prewar = None
         self._d_meta = None
 
-
     def _create_datasets(
-            self, feature: np.ndarray, label: np.ndarray, prewar: np.ndarray | None
+        self, feature: np.ndarray, label: np.ndarray, prewar: np.ndarray | None
     ):
         # feature shape is (C, H, W)
         channels, h, w = feature.shape
@@ -545,11 +554,11 @@ class HDF5Writer:
         self._created = True
 
     def add_entry(
-            self,
-            feature: np.ndarray,
-            label: np.ndarray,
-            meta: dict[str, Any],
-            prewar: np.ndarray | None = None,
+        self,
+        feature: np.ndarray,
+        label: np.ndarray,
+        meta: dict[str, Any],
+        prewar: np.ndarray | None = None,
     ):
         # lazy create on first tile
         if not self._created:
@@ -561,7 +570,9 @@ class HDF5Writer:
         # resize then write each dataset
         self._d_feature.resize(idx + 1, axis=0)
         # ensure dtype matches dataset
-        self._d_feature[idx, :, :, :] = feature.astype(self._d_feature.dtype, copy=False)
+        self._d_feature[idx, :, :, :] = feature.astype(
+            self._d_feature.dtype, copy=False
+        )
 
         self._d_label.resize(idx + 1, axis=0)
         self._d_label[idx, :, :] = label
@@ -701,7 +712,6 @@ def scan_grouped_coordinates(
             return
         src = cropped
 
-    tif_name = os.path.basename(geotiff_path)
     prewar_src = _open_raster(prewar_path) if prewar_path else None
 
     try:
@@ -789,10 +799,10 @@ def scan_grouped_coordinates(
                 )
 
                 if (
-                        feature is not None
-                        and label is not None
-                        and meta is not None
-                        and prewar_tile is not None
+                    feature is not None
+                    and label is not None
+                    and meta is not None
+                    and prewar_tile is not None
                 ):
                     hdf5_writer.add_entry(feature, label, meta, prewar_tile)
                     processed_count += 1
@@ -827,14 +837,14 @@ def scan_grouped_coordinates(
     ):
         # incomplete TIFF: apply quality filter
         if not is_high_quality_tile(
-                feats,
-                date_target,
-                src,
-                lon,
-                lat,
-                step,
-                **quality_thresholds,
-                transformer=transformer,
+            feats,
+            date_target,
+            src,
+            lon,
+            lat,
+            step,
+            **quality_thresholds,
+            transformer=transformer,
         ):
             continue
         feature, label, meta, prewar_tile = process_group(
@@ -850,10 +860,10 @@ def scan_grouped_coordinates(
             min_valid_fraction=min_valid,
         )
         if (
-                feature is not None
-                and label is not None
-                and meta is not None
-                and prewar_tile is not None
+            feature is not None
+            and label is not None
+            and meta is not None
+            and prewar_tile is not None
         ):
             hdf5_writer.add_entry(feature, label, meta, prewar_tile)
             high_quality_found = True
@@ -876,13 +886,14 @@ def scan_all_coordinates(
     prewar_path: str | None = None,
     min_valid_fraction: float = 0.0,
 ):
-    LOGGER.info(f"Scanning entire raster grid for {os.path.basename(geotiff_path)} with step {step} and min_valid_fraction {min_valid_fraction}")
+    LOGGER.info(
+        f"Scanning entire raster grid for {os.path.basename(geotiff_path)} with step {step} and min_valid_fraction {min_valid_fraction}"
+    )
     src = _open_raster(geotiff_path)
     if src is None:
         return
 
     transformer = Transformer.from_crs("EPSG:4326", src.crs, always_xy=True)
-    tif_name = os.path.basename(geotiff_path)
 
     bounds = src.bounds
     lon_bounds, lat_bounds = transform(
@@ -1081,7 +1092,9 @@ def coordinate_scanner(
             return
 
         if not hdf5:
-            raise ValueError("hdf5 must be provided when processing.individual is false")
+            raise ValueError(
+                "hdf5 must be provided when processing.individual is false"
+            )
 
         _ensure_parent_dir(hdf5)
         LOGGER.info(f"Processing {len(tif_files)} TIFF files into {hdf5}")

--- a/displacement_tracker/c_resample_manifest.py
+++ b/displacement_tracker/c_resample_manifest.py
@@ -5,6 +5,7 @@ by whether `label_feature_ids` is empty (negative) or non-empty (positive),
 samples negatives at `null_keep_fraction`, and concatenates kept rows into a
 single output Parquet. No raster I/O — runs in seconds.
 """
+
 from __future__ import annotations
 
 import json
@@ -34,9 +35,7 @@ def resample_and_merge(config_path: str, flow: str | None = "train") -> None:
 
     manifest_dir = config.get("manifest_folder") or config.get("hdf5_folder")
     if not manifest_dir:
-        raise click.ClickException(
-            "Missing required config key: manifest_folder"
-        )
+        raise click.ClickException("Missing required config key: manifest_folder")
     out_path = Path(rebal_config.get("out") or "")
     if not str(out_path):
         raise click.ClickException("Missing required config key: rebalancing.out")
@@ -49,7 +48,9 @@ def resample_and_merge(config_path: str, flow: str | None = "train") -> None:
     rng = np.random.default_rng(rng_seed)
     manifest_dir_path = Path(manifest_dir)
     if not manifest_dir_path.is_dir():
-        print(f"Error: manifest directory not found: {manifest_dir_path}", file=sys.stderr)
+        print(
+            f"Error: manifest directory not found: {manifest_dir_path}", file=sys.stderr
+        )
         sys.exit(1)
 
     if loading_files:

--- a/displacement_tracker/d_train_cnn.py
+++ b/displacement_tracker/d_train_cnn.py
@@ -14,6 +14,7 @@ from displacement_tracker.util.logging_config import setup_logging
 
 LOGGER = setup_logging("train-cnn")
 
+
 class CachedDataset(torch.utils.data.Dataset):
     def __init__(self, base_ds, num_workers: int = 0):
         loader = DataLoader(
@@ -66,7 +67,11 @@ def cli(config: str, flow: str) -> None:
         raise click.ClickException(
             "Missing required config key: manifest (or manifest_folder)"
         )
-    train(manifest_path, artifact_dir=params.get("artifact_dir", "runs"), **params["training"])
+    train(
+        manifest_path,
+        artifact_dir=params.get("artifact_dir", "runs"),
+        **params["training"],
+    )
 
 
 def train(
@@ -76,7 +81,7 @@ def train(
     batch_size: int,
     epochs: int,
     learning_rate: float,
-    weight_decay: float = 0.,
+    weight_decay: float = 0.0,
     sigma: float = 3.0,
     checkpoint: str | None = None,
     device: str | None = None,
@@ -120,7 +125,9 @@ def train(
         LOGGER.info("Caching training dataset in RAM...")
         train_set = CachedDataset(train_set, num_workers=int(num_workers))
         val_set = CachedDataset(val_set, num_workers=int(num_workers))
-        LOGGER.info(f"Cached {len(train_set)} training and {len(val_set)} validation samples.")
+        LOGGER.info(
+            f"Cached {len(train_set)} training and {len(val_set)} validation samples."
+        )
         loader_workers = 0
     else:
         loader_workers = int(num_workers)
@@ -145,15 +152,17 @@ def train(
         # pixelwise loss
         mse = torch.nn.functional.mse_loss(x, y)
 
-        # count loss (mass difference)
-        pred_count = x.sum(dim=(1, 2, 3))
-        true_count = y.sum(dim=(1, 2, 3))
-        count_loss = torch.nn.functional.mse_loss(pred_count, true_count)
+        # count loss (mass difference) — currently disabled; small weight
+        # would keep spatial quality dominant if re-enabled:
+        # pred_count = x.sum(dim=(1, 2, 3))
+        # true_count = y.sum(dim=(1, 2, 3))
+        # count_loss = torch.nn.functional.mse_loss(pred_count, true_count)
+        # return 1e6 * mse + 0.1 * count_loss
+        return 1e6 * mse
 
-        # small weight keeps spatial quality dominant
-        return 1e6 * mse # + 0.1 * count_loss
-
-    optimizer = optim.Adam(model.parameters(), lr=learning_rate, weight_decay=weight_decay)
+    optimizer = optim.Adam(
+        model.parameters(), lr=learning_rate, weight_decay=weight_decay
+    )
 
     # Create timestamped run directory
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/displacement_tracker/d_train_cnn.py
+++ b/displacement_tracker/d_train_cnn.py
@@ -152,12 +152,7 @@ def train(
         # pixelwise loss
         mse = torch.nn.functional.mse_loss(x, y)
 
-        # count loss (mass difference) — currently disabled; small weight
-        # would keep spatial quality dominant if re-enabled:
-        # pred_count = x.sum(dim=(1, 2, 3))
-        # true_count = y.sum(dim=(1, 2, 3))
-        # count_loss = torch.nn.functional.mse_loss(pred_count, true_count)
-        # return 1e6 * mse + 0.1 * count_loss
+        # a count loss (mass difference) term was tried here and dropped
         return 1e6 * mse
 
     optimizer = optim.Adam(

--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -63,11 +63,15 @@ def extract_tile_centroids(probs_np, bounds, threshold, min_area, crop_pixels=0)
     return coords
 
 
-def extract_tile_nms(probs_np, bounds, threshold, factor=1.0, kernel_size=7, sigma=50.0, crop_pixels=0):
+def extract_tile_nms(
+    probs_np, bounds, threshold, factor=1.0, kernel_size=7, sigma=50.0, crop_pixels=0
+):
     """Return interpolated local maxima (lat, lon, peak_value) above threshold."""
     probs_t = torch.as_tensor(probs_np, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
     blurred_np = gaussian_filter(probs_np, sigma=sigma)
-    blurred_t = torch.as_tensor(blurred_np, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+    blurred_t = (
+        torch.as_tensor(blurred_np, dtype=torch.float32).unsqueeze(0).unsqueeze(0)
+    )
     score_t = probs_t + blurred_t * factor
 
     # Pad manually so the pooled map always matches score_t's shape: max_pool2d's
@@ -138,7 +142,8 @@ def predict(
     agreement = selection_cfg.get("agreement", False)
     min_distance_m = selection_cfg.get("min_distance_m", 2.0)
     factor = selection_cfg.get("factor", 0.0)
-    LOGGER.info(f"🔹 Prediction selection parameters: method={selection_cfg.get('method', 'centroid')}, "
+    LOGGER.info(
+        f"🔹 Prediction selection parameters: method={selection_cfg.get('method', 'centroid')}, "
         f"threshold={threshold}, min_area={min_area}, nms_kernel_size={nms_kernel_size}, "
         f"crop_pixels={crop_pixels}, nms_sigma={nms_sigma}, agreement={agreement}, "
         f"min_distance_m={min_distance_m}, factor={factor}"
@@ -147,9 +152,7 @@ def predict(
     batch_size = max(1, int(batch_size))
 
     if method not in {"centroid", "nms"}:
-        raise click.ClickException(
-            "selection.method must be one of: 'centroid', 'nms'"
-        )
+        raise click.ClickException("selection.method must be one of: 'centroid', 'nms'")
 
     if method == "nms" and "min_area" in selection_cfg:
         raise click.ClickException(
@@ -224,7 +227,7 @@ def predict(
                         postfix["rss_gb"] = f"{mem_gb:.2f}"
                         if device.type == "cuda":
                             postfix["cuda_gb"] = (
-                                f"{torch.cuda.memory_allocated(device)/(1024**3):.2f}"
+                                f"{torch.cuda.memory_allocated(device) / (1024**3):.2f}"
                             )
 
                     try:
@@ -254,11 +257,21 @@ def predict(
 
                             if method == "nms":
                                 coords = extract_tile_nms(
-                                    probs_np, bounds, threshold, factor=factor, kernel_size=nms_kernel_size, sigma=nms_sigma, crop_pixels=crop_pixels
+                                    probs_np,
+                                    bounds,
+                                    threshold,
+                                    factor=factor,
+                                    kernel_size=nms_kernel_size,
+                                    sigma=nms_sigma,
+                                    crop_pixels=crop_pixels,
                                 )
                             else:
                                 coords = extract_tile_centroids(
-                                    probs_np, bounds, threshold, min_area, crop_pixels=crop_pixels
+                                    probs_np,
+                                    bounds,
+                                    threshold,
+                                    min_area,
+                                    crop_pixels=crop_pixels,
                                 )
 
                             tile_tent_count = len(coords)
@@ -303,13 +316,15 @@ def predict(
         tmp_ndjson.unlink()
     except Exception:
         pass
-    
+
     print("")  # add new line after tqdm bars
 
     LOGGER.info(f"Total number of tents (pre-merge): {len(flat_results)}")
 
     # Only keep points with agreement between overlaps
-    if isinstance(agreement, bool):  # convert to int, False -> 1 point agreement, True -> 2 point agreement
+    if isinstance(
+        agreement, bool
+    ):  # convert to int, False -> 1 point agreement, True -> 2 point agreement
         agreement = 2 if agreement else 1
 
     # global deduplication in meters
@@ -416,7 +431,9 @@ def run_prediction_job(
     num_workers,
     per_tile_standardisation=False,
 ):
-    dataset = PairedImageDataset(str(input_path), per_tile_standardisation=per_tile_standardisation)
+    dataset = PairedImageDataset(
+        str(input_path), per_tile_standardisation=per_tile_standardisation
+    )
     try:
         results = predict(
             dataset,
@@ -456,7 +473,9 @@ def cli(config, flow) -> None:
 
     processing_cfg = params.get("processing", {})
     if "margin_metres" not in processing_cfg:
-        raise click.ClickException("Missing required config key: processing.margin_metres")
+        raise click.ClickException(
+            "Missing required config key: processing.margin_metres"
+        )
     margin_metres = float(processing_cfg["margin_metres"])
     margin_pixels = int(round(margin_metres / PIXEL_METRES))
     selection_cfg["crop_pixels"] = margin_pixels

--- a/displacement_tracker/evaluation/annotation_reference.py
+++ b/displacement_tracker/evaluation/annotation_reference.py
@@ -203,9 +203,7 @@ def cli(annotation_csv, date, master_grid, output, count_column):
     )
 
     with rasterio.open(master_grid) as src:
-        counts = source.counts_on_grid(
-            (src.height, src.width), src.transform, src.crs
-        )
+        counts = source.counts_on_grid((src.height, src.width), src.transform, src.crs)
         profile = src.profile.copy()
 
     profile.update(driver="GTiff", count=1, dtype="float32", nodata=0.0)

--- a/displacement_tracker/evaluation/manual_eval/manual_eval.py
+++ b/displacement_tracker/evaluation/manual_eval/manual_eval.py
@@ -141,47 +141,6 @@ def random_tile_within_polygon(src, polygon_gdf):
     raise RuntimeError("Failed to sample valid tile after many attempts.")
 
 
-def count_predictions_in_tile(tile_geom, geojson_path, raster_crs, tif_path):
-    """
-    Count number of prediction points inside tile.
-    Ensures CRS alignment and verifies spatial overlap.
-    """
-
-    if not os.path.exists(geojson_path):
-        print("GeoJSON not found:", geojson_path)
-        return 0
-
-    preds = gpd.read_file(geojson_path)
-
-    if preds.empty:
-        return 0
-
-    # If CRS missing, assume WGS84 (very common for GeoJSON)
-    if preds.crs is None:
-        preds.set_crs("EPSG:4326", inplace=True)
-
-    # Reproject predictions to raster CRS
-    preds = preds.to_crs(raster_crs)
-
-    # Quick sanity check: do predictions overlap raster at all?
-    raster_bounds_geom = box(*rasterio.open(tif_path).bounds)
-
-    if not preds.total_bounds.any():
-        return 0
-
-    # Filter predictions to raster extent first
-    preds = preds[preds.intersects(raster_bounds_geom)]
-
-    if preds.empty:
-        print("Predictions do not overlap raster after reprojection.")
-        return 0
-
-    # Now count points inside tile
-    count = preds.within(tile_geom).sum()
-
-    return int(count)
-
-
 def show_tile_and_get_count(tile_array, prewar_array):
     """
     Display current and prewar tiles side by side.

--- a/displacement_tracker/evaluation/manual_eval/manual_eval.py
+++ b/displacement_tracker/evaluation/manual_eval/manual_eval.py
@@ -80,6 +80,7 @@ TILE_SIZE_METERS = 100
 # HELPER FUNCTIONS
 # ==========================
 
+
 def parse_tif_name(filename):
     """
     Parse filename into:
@@ -140,7 +141,7 @@ def random_tile_within_polygon(src, polygon_gdf):
     raise RuntimeError("Failed to sample valid tile after many attempts.")
 
 
-def count_predictions_in_tile(tile_geom, geojson_path, raster_crs):
+def count_predictions_in_tile(tile_geom, geojson_path, raster_crs, tif_path):
     """
     Count number of prediction points inside tile.
     Ensures CRS alignment and verifies spatial overlap.
@@ -232,6 +233,7 @@ def show_tile_and_get_count(tile_array, prewar_array):
 # MAIN PROCESS
 # ==========================
 
+
 def main():
 
     if not TIF_LIST:
@@ -261,7 +263,6 @@ def main():
 
         with rasterio.open(tif_path) as src:
             with rasterio.open(PREWAR_TIF) as prewar_src:
-
                 # ---- Load and align predictions ONCE ----
                 if os.path.exists(geojson_path):
                     preds = gpd.read_file(geojson_path)
@@ -292,20 +293,20 @@ def main():
 
                     tile_geom = random_tile_within_polygon(src, gaza_boundary)
 
-                    window = from_bounds(
-                        *tile_geom.bounds,
-                        transform=src.transform
-                    )
+                    window = from_bounds(*tile_geom.bounds, transform=src.transform)
 
                     # prepare prewar window, reproject tile_geom to prewar CRS if necessary
                     if prewar_src.crs == src.crs:
                         prewar_geom = tile_geom
                     else:
-                        prewar_geom = gpd.GeoSeries([tile_geom], crs=src.crs).to_crs(prewar_src.crs).iloc[0]
+                        prewar_geom = (
+                            gpd.GeoSeries([tile_geom], crs=src.crs)
+                            .to_crs(prewar_src.crs)
+                            .iloc[0]
+                        )
 
                     prewar_window = from_bounds(
-                        *prewar_geom.bounds,
-                        transform=prewar_src.transform
+                        *prewar_geom.bounds, transform=prewar_src.transform
                     )
 
                     # safe reads: skip tile if reading fails (out-of-range)
@@ -351,30 +352,33 @@ def main():
                     centroid = tile_geom.centroid
 
                     # Convert centroid to lat/lon
-                    centroid_gdf = gpd.GeoSeries(
-                        [centroid],
-                        crs=src.crs
-                    ).to_crs("EPSG:4326")
+                    centroid_gdf = gpd.GeoSeries([centroid], crs=src.crs).to_crs(
+                        "EPSG:4326"
+                    )
 
                     lon = centroid_gdf.x.values[0]
                     lat = centroid_gdf.y.values[0]
 
-                    rows.append({
-                        "region": region,
-                        "date": date,
-                        "time": time,
-                        "satellite": satellite,
-                        "tif_name": tif_name,
-                        "latitude": lat,
-                        "longitude": lon,
-                        "manual_tent_count": manual_count,
-                        "model_tent_count": model_count
-                    })
+                    rows.append(
+                        {
+                            "region": region,
+                            "date": date,
+                            "time": time,
+                            "satellite": satellite,
+                            "tif_name": tif_name,
+                            "latitude": lat,
+                            "longitude": lon,
+                            "manual_tent_count": manual_count,
+                            "model_tent_count": model_count,
+                        }
+                    )
 
                     accepted += 1
 
                 if accepted < N_TILES_PER_IMAGE:
-                    print(f"Warning: only collected {accepted}/{N_TILES_PER_IMAGE} tiles for {tif_name} after {attempts} attempts.")
+                    print(
+                        f"Warning: only collected {accepted}/{N_TILES_PER_IMAGE} tiles for {tif_name} after {attempts} attempts."
+                    )
 
     df = pd.DataFrame(rows)
 

--- a/displacement_tracker/evaluation/scripts/add_new_model_results.py
+++ b/displacement_tracker/evaluation/scripts/add_new_model_results.py
@@ -59,7 +59,9 @@ def _count_predictions_for_date(
 
     half = tile_size_meters / 2
     tiles = gpd.GeoDataFrame(
-        geometry=[box(c.x - half, c.y - half, c.x + half, c.y + half) for c in centroids],
+        geometry=[
+            box(c.x - half, c.y - half, c.x + half, c.y + half) for c in centroids
+        ],
         index=group.index,
         crs=raster_crs,
     )
@@ -107,6 +109,8 @@ def add_new_model_results(
         )
 
     df.to_csv(output_csv, index=False)
-    LOGGER.info("Saved updated CSV to %s (added column %s)", output_csv, actual_column_name)
+    LOGGER.info(
+        "Saved updated CSV to %s (added column %s)", output_csv, actual_column_name
+    )
 
     return output_csv, actual_column_name

--- a/displacement_tracker/evaluation/scripts/common.py
+++ b/displacement_tracker/evaluation/scripts/common.py
@@ -28,6 +28,7 @@ Z_95 = 1.96
 # ANNOTATION AND LAYER LOADING
 # ==========================================================
 
+
 def read_annotations(annotation_csv: str, required_columns=()) -> pd.DataFrame:
     """Read the annotation CSV and validate that required columns exist."""
     df = pd.read_csv(annotation_csv)
@@ -57,9 +58,7 @@ def load_annotations(
     extra_columns: tuple = (),
 ) -> pd.DataFrame:
     """Read the annotation CSV and add a tile_error column."""
-    df = read_annotations(
-        annotation_csv, {manual_column, model_column, *extra_columns}
-    )
+    df = read_annotations(annotation_csv, {manual_column, model_column, *extra_columns})
     df["tile_error"] = df[model_column] - df[manual_column]
     return df
 
@@ -103,6 +102,7 @@ def finite_xy(x, y):
 # ERROR SUMMARIES
 # ==========================================================
 
+
 def mean_error_ci(errors, z: float = Z_95) -> dict | None:
     """Mean error with sample std and a normal-approximation CI.
 
@@ -145,6 +145,7 @@ def group_error_summary(
 # ==========================================================
 # HEX GRID
 # ==========================================================
+
 
 def choose_utm_crs_from_gdf(gdf: gpd.GeoDataFrame) -> CRS:
     """Choose a UTM CRS based on the centroid of the layer."""
@@ -225,11 +226,15 @@ def hex_error_aggregation(
     points_with_hex = points_with_hex.dropna(subset=["hex_id"]).copy()
     points_with_hex["hex_id"] = points_with_hex["hex_id"].astype(int)
 
-    agg = points_with_hex.groupby("hex_id").agg(
-        n_tiles=("tile_error", "size"),
-        mean_err=("tile_error", "mean"),
-        std_err=("tile_error", "std"),
-    ).reset_index()
+    agg = (
+        points_with_hex.groupby("hex_id")
+        .agg(
+            n_tiles=("tile_error", "size"),
+            mean_err=("tile_error", "mean"),
+            std_err=("tile_error", "std"),
+        )
+        .reset_index()
+    )
 
     hex_gdf = hex_gdf.merge(agg, on="hex_id", how="left")
     hex_gdf["n_tiles"] = hex_gdf["n_tiles"].fillna(0).astype(int)

--- a/displacement_tracker/evaluation/scripts/evaluate_destruction.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_destruction.py
@@ -51,8 +51,8 @@ def evaluate_destruction_vs_non_destruction(
 
     # A tile can match several polygons; it counts as 'Destruction' if any
     # matching polygon was already destroyed by the tile date.
-    joined["active_destruction"] = (
-        joined["date_start"].notna() & (joined["date_start"] <= joined["date"])
+    joined["active_destruction"] = joined["date_start"].notna() & (
+        joined["date_start"] <= joined["date"]
     )
     collapsed = joined.groupby(joined.index).agg(
         {"tile_error": "first", "active_destruction": "max"}

--- a/displacement_tracker/evaluation/scripts/evaluate_municipal_bounds.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_municipal_bounds.py
@@ -77,11 +77,16 @@ def evaluate_municipal_bounds(
     )
 
     _plot_municipal_map(
-        municipal_gdf, results_df, name_column,
+        municipal_gdf,
+        results_df,
+        name_column,
         os.path.join(output_dir, "municipal_bounds_map.png"),
     )
     _plot_municipal_scatter(
-        joined, name_column, manual_column, model_column,
+        joined,
+        name_column,
+        manual_column,
+        model_column,
         os.path.join(output_dir, "municipal_scatter_subplots.png"),
     )
 
@@ -92,7 +97,10 @@ def _plot_municipal_map(municipal_gdf, results_df, name_column, output_map):
     """Choropleth of mean tile error per municipality."""
     map_gdf = municipal_gdf.merge(results_df, on=name_column, how="left")
 
-    if "mean_tile_error" not in map_gdf.columns or not map_gdf["mean_tile_error"].notna().any():
+    if (
+        "mean_tile_error" not in map_gdf.columns
+        or not map_gdf["mean_tile_error"].notna().any()
+    ):
         LOGGER.warning("No valid regional error values available for map plot.")
         return
 
@@ -114,7 +122,9 @@ def _plot_municipal_map(municipal_gdf, results_df, name_column, output_map):
     plt.close()
 
 
-def _plot_municipal_scatter(joined, name_column, manual_column, model_column, output_scatter):
+def _plot_municipal_scatter(
+    joined, name_column, manual_column, model_column, output_scatter
+):
     """Per-municipality manual-vs-model scatter subplots with a 1:1 line."""
     unique_regions = sorted(joined[name_column].dropna().unique())
     if not unique_regions:
@@ -145,7 +155,7 @@ def _plot_municipal_scatter(joined, name_column, manual_column, model_column, ou
         ax.set_xlabel("Manual")
         ax.set_ylabel("Model")
 
-    for ax in axes[len(unique_regions):]:
+    for ax in axes[len(unique_regions) :]:
         ax.axis("off")
 
     plt.tight_layout()

--- a/displacement_tracker/evaluation/scripts/evaluate_spatial_points.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_spatial_points.py
@@ -26,7 +26,9 @@ def evaluate_spatial_points(
     output_path = os.path.join(output_dir, "spatial_tile_error_hexbin.png")
 
     df = load_annotations(
-        annotation_csv, manual_column, model_column,
+        annotation_csv,
+        manual_column,
+        model_column,
         extra_columns=("latitude", "longitude"),
     )
     if df.empty:

--- a/displacement_tracker/evaluation/scripts/evaluate_tile_correlation.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_tile_correlation.py
@@ -53,10 +53,34 @@ def evaluate_tile_correlation(
     y_nz = nonzero[model_column].to_numpy(dtype=float)
 
     variants = {
-        "linear_all": (x_all, y_all, False, "Linear", "tile_prediction_correlation_linear.png"),
-        "log_all": (x_all, y_all, True, "Log Scale", "tile_prediction_correlation_log.png"),
-        "linear_nonzero": (x_nz, y_nz, False, "Linear, Manual > 0", "tile_prediction_correlation_linear_nonzero.png"),
-        "log_nonzero": (x_nz, y_nz, True, "Log, Manual > 0", "tile_prediction_correlation_log_nonzero.png"),
+        "linear_all": (
+            x_all,
+            y_all,
+            False,
+            "Linear",
+            "tile_prediction_correlation_linear.png",
+        ),
+        "log_all": (
+            x_all,
+            y_all,
+            True,
+            "Log Scale",
+            "tile_prediction_correlation_log.png",
+        ),
+        "linear_nonzero": (
+            x_nz,
+            y_nz,
+            False,
+            "Linear, Manual > 0",
+            "tile_prediction_correlation_linear_nonzero.png",
+        ),
+        "log_nonzero": (
+            x_nz,
+            y_nz,
+            True,
+            "Log, Manual > 0",
+            "tile_prediction_correlation_log_nonzero.png",
+        ),
     }
 
     results = {}
@@ -73,7 +97,10 @@ def evaluate_tile_correlation(
         output_path = os.path.join(output_dir, filename)
 
         plot_scatter_with_1to1(
-            x, y, xlabel, ylabel,
+            x,
+            y,
+            xlabel,
+            ylabel,
             title=(
                 f"Tile-Level Prediction Correlation ({scale_label})\n"
                 f"Pearson r = {r:.3f}"

--- a/displacement_tracker/evaluation/scripts/spatial_bootstrap_hex.py
+++ b/displacement_tracker/evaluation/scripts/spatial_bootstrap_hex.py
@@ -74,7 +74,9 @@ def spatial_bootstrap_hex(
     # Spatial (block) bootstrap for the regional total: resample whole hexes.
     blocks = hex_gdf[hex_gdf["n_tiles"] > 0].copy()
     if blocks.empty:
-        raise ValueError("No hexes contain annotations; cannot perform block bootstrap.")
+        raise ValueError(
+            "No hexes contain annotations; cannot perform block bootstrap."
+        )
 
     blocks["total_err_hex"] = blocks["mean_err"] * blocks["n_tiles"]
     totals_arr = blocks["total_err_hex"].values
@@ -111,16 +113,20 @@ def spatial_bootstrap_hex(
         significant=significant,
     )
 
-    summary_df = pd.DataFrame([{
-        "region_total_error_estimate": region_total_est,
-        "region_total_error_ci_lo": region_lo,
-        "region_total_error_ci_hi": region_hi,
-        "region_mean_error_estimate": region_mean_obs,
-        "region_mean_error_ci_lo": region_mean_lo,
-        "region_mean_error_ci_hi": region_mean_hi,
-        "n_hex_blocks": nblocks,
-        "n_tiles_used": total_tiles_in_blocks,
-    }])
+    summary_df = pd.DataFrame(
+        [
+            {
+                "region_total_error_estimate": region_total_est,
+                "region_total_error_ci_lo": region_lo,
+                "region_total_error_ci_hi": region_hi,
+                "region_mean_error_estimate": region_mean_obs,
+                "region_mean_error_ci_lo": region_mean_lo,
+                "region_mean_error_ci_hi": region_mean_hi,
+                "n_hex_blocks": nblocks,
+                "n_tiles_used": total_tiles_in_blocks,
+            }
+        ]
+    )
     summary_df.to_csv(out_summary_csv, index=False)
 
     return hex_gdf

--- a/displacement_tracker/evaluation/scripts/total_error.py
+++ b/displacement_tracker/evaluation/scripts/total_error.py
@@ -50,7 +50,9 @@ def evaluate_total_error(
     # Analytic CI for the mean error per hex, and for the total error
     # extrapolated to every tile the hex could contain.
     hex_gdf["hex_area_m2"] = hex_gdf.geometry.area
-    hex_gdf["N_total_tiles"] = (hex_gdf["hex_area_m2"] / TILE_AREA_M2).round().astype(int)
+    hex_gdf["N_total_tiles"] = (
+        (hex_gdf["hex_area_m2"] / TILE_AREA_M2).round().astype(int)
+    )
 
     hex_gdf["se_mean"] = hex_gdf["std_err"] / np.sqrt(hex_gdf["n_tiles"])
     hex_gdf.loc[hex_gdf["n_tiles"] <= 1, "se_mean"] = np.nan
@@ -64,9 +66,16 @@ def evaluate_total_error(
     hex_gdf["ci_hi_total"] = hex_gdf["total_err_est"] + z * hex_gdf["se_total_est"]
 
     round_cols = [
-        "hex_area_m2", "mean_err", "std_err", "se_mean",
-        "ci_lo_mean", "ci_hi_mean",
-        "total_err_est", "se_total_est", "ci_lo_total", "ci_hi_total",
+        "hex_area_m2",
+        "mean_err",
+        "std_err",
+        "se_mean",
+        "ci_lo_mean",
+        "ci_hi_mean",
+        "total_err_est",
+        "se_total_est",
+        "ci_lo_total",
+        "ci_hi_total",
     ]
     for c in round_cols:
         if pd.api.types.is_numeric_dtype(hex_gdf[c]):

--- a/displacement_tracker/g1_scan_validation.py
+++ b/displacement_tracker/g1_scan_validation.py
@@ -86,12 +86,13 @@ def _make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
     val_raster_base = grouped["val_raster"]
     mask_array = grouped["mask_array"]
     grid_shape = grouped["grid_shape"]
-    nodata_val = grouped["nodata_val"]
     rows_arr = pred_prepped["row"].to_numpy(dtype=np.int32)
     cols_arr = pred_prepped["col"].to_numpy(dtype=np.int32)
 
     def evaluate(factor: float, cutoff: float) -> Optional[Dict[str, float]]:
-        keep = keep_mask_from_params(pred_prepped, factor=float(factor), cutoff=float(cutoff))
+        keep = keep_mask_from_params(
+            pred_prepped, factor=float(factor), cutoff=float(cutoff)
+        )
         try:
             processed = process_grouped_cells(
                 pred_rows=rows_arr[keep],
@@ -109,8 +110,11 @@ def _make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
             processed["mask_array"],
         )
         trace.append(
-            {"factor": float(factor), "cutoff": float(cutoff),
-             **{m: metrics[m] for m in scan_metrics}}
+            {
+                "factor": float(factor),
+                "cutoff": float(cutoff),
+                **{m: metrics[m] for m in scan_metrics},
+            }
         )
         for m in scan_metrics:
             v = metrics[m]
@@ -233,7 +237,12 @@ def scan_tile(
       ridges[m]  = (a, b) of the fitted ridge cutoff = a*factor + b
     """
     bests = {
-        m: {"value": initial_best_value(m), "factor": None, "cutoff": None, "keep": None}
+        m: {
+            "value": initial_best_value(m),
+            "factor": None,
+            "cutoff": None,
+            "keep": None,
+        }
         for m in scan_metrics
     }
     trace: List[Dict[str, float]] = []
@@ -297,8 +306,12 @@ def plot_search_trace(
         bv = bests[metric]
         if bv["factor"] is not None:
             ax.scatter(
-                bv["factor"], bv["cutoff"],
-                color="white", edgecolor="black", marker="*", s=140,
+                bv["factor"],
+                bv["cutoff"],
+                color="white",
+                edgecolor="black",
+                marker="*",
+                s=140,
                 label=f"best {metric}",
             )
 
@@ -368,8 +381,7 @@ def _scan_settings(params: dict) -> ScanSettings:
     input_path = tuning.get("input") or merge_cfg.get("output")
     if not input_path:
         raise click.ClickException(
-            "Missing required config key: tuning.input "
-            "(or merge.output as fallback)"
+            "Missing required config key: tuning.input (or merge.output as fallback)"
         )
     out_dir = tuning.get("out_dir") or "scan_results"
     metric, scan_metrics = _resolve_metrics(tuning)
@@ -522,10 +534,9 @@ def run_scan(params: dict) -> dict:
         settings.reference, nearest_to=_prediction_date(settings)
     )
 
-    total_evals = (
-        _budget_per_metric(settings.ridge_probes, settings.refine_maxiter)
-        * len(settings.scan_metrics)
-    )
+    total_evals = _budget_per_metric(
+        settings.ridge_probes, settings.refine_maxiter
+    ) * len(settings.scan_metrics)
     pbar = tqdm(total=total_evals, desc="evals", unit="eval")
 
     with rasterio.open(settings.master_grid) as src_grid:
@@ -534,8 +545,7 @@ def run_scan(params: dict) -> dict:
             grouped = prepare_grouped_cell_inputs(pred_gdf, reference, src_grid)
         except Exception as exc:
             raise click.ClickException(
-                f"Could not resolve {settings.input_path} onto the master "
-                f"grid: {exc}"
+                f"Could not resolve {settings.input_path} onto the master grid: {exc}"
             ) from exc
 
         bests, trace, ridges = scan_tile(
@@ -559,7 +569,9 @@ def run_scan(params: dict) -> dict:
         click.echo(f"{settings.base_name} ({len(trace)} evals) -> {best_summary}")
 
         plot_search_trace(
-            trace=trace, bests=bests, ridges=ridges,
+            trace=trace,
+            bests=bests,
+            ridges=ridges,
             factor_bounds=settings.factor_bounds,
             cutoff_bounds=settings.cutoff_bounds,
             out_path=Path(settings.out_dir) / f"{settings.base_name}_search_trace.png",

--- a/displacement_tracker/h2_merge_tuned.py
+++ b/displacement_tracker/h2_merge_tuned.py
@@ -55,21 +55,15 @@ def cli(config: str, flow: str) -> None:
 
     input_folder = merge_cfg.get("input_folder")
     if not input_folder:
-        raise click.ClickException(
-            "Missing required config key: merge.input_folder"
-        )
+        raise click.ClickException("Missing required config key: merge.input_folder")
     output = tuning.get("final_output")
     if not output:
-        raise click.ClickException(
-            "Missing required config key: tuning.final_output"
-        )
+        raise click.ClickException("Missing required config key: tuning.final_output")
     best_params_path = tuning.get("best_params")
     if not best_params_path and tuning.get("out_dir"):
         best_params_path = str(Path(tuning["out_dir"]) / "best_params.yaml")
     if not best_params_path:
-        raise click.ClickException(
-            "Missing required config key: tuning.best_params"
-        )
+        raise click.ClickException("Missing required config key: tuning.best_params")
 
     best = load_best_params(best_params_path)
     LOGGER.info(

--- a/displacement_tracker/h_merge_geojsons.py
+++ b/displacement_tracker/h_merge_geojsons.py
@@ -137,9 +137,7 @@ def load_zone_geometry(zones_path: str | None, label: str):
         return None
 
     if zones_gdf.crs is None:
-        LOGGER.warning(
-            "%s zones CRS missing, assuming EPSG:4326: %s", label, path
-        )
+        LOGGER.warning("%s zones CRS missing, assuming EPSG:4326: %s", label, path)
         zones_gdf = zones_gdf.set_crs("EPSG:4326")
     else:
         zones_gdf = zones_gdf.to_crs("EPSG:4326")
@@ -228,7 +226,10 @@ def process_geojson_folder(
         pts = filter_points_by_adjusted_peak(pts, threshold, adjustment_factor)
         LOGGER.info(
             "  %s: %d points loaded, %d kept (adj_peak >= %.4f)",
-            path.name, loaded, len(pts), threshold,
+            path.name,
+            loaded,
+            len(pts),
+            threshold,
         )
 
         for label, zone_geom, keep_inside in (

--- a/displacement_tracker/i_zonal_point_sums.py
+++ b/displacement_tracker/i_zonal_point_sums.py
@@ -32,7 +32,9 @@ def resolve_path(base_dir: Path, path_value: str) -> Path:
     return path if path.is_absolute() else (base_dir / path)
 
 
-def load_gdf(path: Path, label: str, fallback_crs: str | None = None) -> gpd.GeoDataFrame:
+def load_gdf(
+    path: Path, label: str, fallback_crs: str | None = None
+) -> gpd.GeoDataFrame:
     if not path.exists():
         raise click.ClickException(f"{label} not found: {path}")
     try:
@@ -80,7 +82,9 @@ def summarize_points_by_zone(
     zones_cols = zones_gdf[[zone_id_column, "geometry"]].copy()
     joined = gpd.sjoin(points_gdf, zones_cols, how="left", predicate="within")
 
-    value_cols = [col for col in ["peak_value", "adjusted_peak"] if col in joined.columns]
+    value_cols = [
+        col for col in ["peak_value", "adjusted_peak"] if col in joined.columns
+    ]
     grouped = (
         joined.groupby(zone_id_column, dropna=False)
         .agg({"geometry": "count"})
@@ -117,29 +121,45 @@ def write_zone_summary(
     )
 
     zones_with_summary = zones_gdf.merge(summary_df, on=zone_id_column, how="left")
-    zones_with_summary["tent_count"] = zones_with_summary["tent_count"].fillna(0).astype(int)
+    zones_with_summary["tent_count"] = (
+        zones_with_summary["tent_count"].fillna(0).astype(int)
+    )
     if "peak_value" in value_cols:
-        zones_with_summary["peak_value_median"] = zones_with_summary["peak_value_median"].fillna(0.0)
-        zones_with_summary["peak_value_iqr"] = zones_with_summary["peak_value_iqr"].fillna(0.0)
+        zones_with_summary["peak_value_median"] = zones_with_summary[
+            "peak_value_median"
+        ].fillna(0.0)
+        zones_with_summary["peak_value_iqr"] = zones_with_summary[
+            "peak_value_iqr"
+        ].fillna(0.0)
     if "adjusted_peak" in value_cols:
-        zones_with_summary["adjusted_peak_median"] = zones_with_summary["adjusted_peak_median"].fillna(0.0)
-        zones_with_summary["adjusted_peak_iqr"] = zones_with_summary["adjusted_peak_iqr"].fillna(0.0)
+        zones_with_summary["adjusted_peak_median"] = zones_with_summary[
+            "adjusted_peak_median"
+        ].fillna(0.0)
+        zones_with_summary["adjusted_peak_iqr"] = zones_with_summary[
+            "adjusted_peak_iqr"
+        ].fillna(0.0)
 
     output_csv = output_dir / f"zonal_sum_{zone_name}.csv"
     output_gpkg = output_dir / f"zonal_sum_{zone_name}.gpkg"
-    (zones_with_summary.drop(columns=["geometry"], errors="ignore")).to_csv(output_csv, index=False)
+    (zones_with_summary.drop(columns=["geometry"], errors="ignore")).to_csv(
+        output_csv, index=False
+    )
     zones_with_summary.to_file(output_gpkg, driver="GPKG")
     LOGGER.info("Saved %s zonal summary CSV: %s", zone_name, output_csv)
     LOGGER.info("Saved %s zonal summary GPKG: %s", zone_name, output_gpkg)
 
 
-def write_master_grid_tent_count_tiff(points_gdf: gpd.GeoDataFrame, master_grid_path: Path, output_dir: Path) -> None:
+def write_master_grid_tent_count_tiff(
+    points_gdf: gpd.GeoDataFrame, master_grid_path: Path, output_dir: Path
+) -> None:
     if not master_grid_path.exists():
         raise click.ClickException(f"Master grid raster not found: {master_grid_path}")
 
     with rasterio.open(master_grid_path) as src:
         if src.crs is None:
-            raise click.ClickException(f"Master grid CRS is missing: {master_grid_path}")
+            raise click.ClickException(
+                f"Master grid CRS is missing: {master_grid_path}"
+            )
 
         points_in_grid = points_gdf.to_crs(src.crs)
         xs = points_in_grid.geometry.x.to_numpy()
@@ -148,12 +168,7 @@ def write_master_grid_tent_count_tiff(points_gdf: gpd.GeoDataFrame, master_grid_
 
         rows = np.asarray(rows)
         cols = np.asarray(cols)
-        in_bounds = (
-            (rows >= 0)
-            & (rows < src.height)
-            & (cols >= 0)
-            & (cols < src.width)
-        )
+        in_bounds = (rows >= 0) & (rows < src.height) & (cols >= 0) & (cols < src.width)
 
         counts = np.zeros((src.height, src.width), dtype=np.int32)
         if np.any(in_bounds):
@@ -170,10 +185,20 @@ def write_master_grid_tent_count_tiff(points_gdf: gpd.GeoDataFrame, master_grid_
 
 
 @click.command()
-@click.option("--points-gpkg", default="results/TentNetFA/final/merged_points.gpkg", show_default=True)
-@click.option("--neighbourhood-zones", default="boundaries/neighbourhoods.gpkg", show_default=True)
-@click.option("--municipality-zones", default="boundaries/municipalities.gpkg", show_default=True)
-@click.option("--governorate-zones", default="boundaries/governorates.gpkg", show_default=True)
+@click.option(
+    "--points-gpkg",
+    default="results/TentNetFA/final/merged_points.gpkg",
+    show_default=True,
+)
+@click.option(
+    "--neighbourhood-zones", default="boundaries/neighbourhoods.gpkg", show_default=True
+)
+@click.option(
+    "--municipality-zones", default="boundaries/municipalities.gpkg", show_default=True
+)
+@click.option(
+    "--governorate-zones", default="boundaries/governorates.gpkg", show_default=True
+)
 @click.option(
     "--master-grid",
     default=None,
@@ -183,7 +208,9 @@ def write_master_grid_tent_count_tiff(points_gdf: gpd.GeoDataFrame, master_grid_
 @click.option("--neighbourhood-id-column", default="name", show_default=True)
 @click.option("--municipality-id-column", default="NAME", show_default=True)
 @click.option("--governorate-id-column", default="name", show_default=True)
-@click.option("--output-dir", default="results/TentNetFA/final/zonal_summaries", show_default=True)
+@click.option(
+    "--output-dir", default="results/TentNetFA/final/zonal_summaries", show_default=True
+)
 def cli(
     points_gpkg: str,
     neighbourhood_zones: str,
@@ -206,11 +233,27 @@ def cli(
 
     output_path.mkdir(parents=True, exist_ok=True)
 
-    points_gdf = load_gdf(points_path, "merged point GeoPackage", fallback_crs="EPSG:4326")
+    points_gdf = load_gdf(
+        points_path, "merged point GeoPackage", fallback_crs="EPSG:4326"
+    )
 
-    write_zone_summary(points_gdf, neighbourhood_path, "neighbourhood", neighbourhood_id_column, output_path)
-    write_zone_summary(points_gdf, municipality_path, "municipality", municipality_id_column, output_path)
-    write_zone_summary(points_gdf, governorate_path, "governorate", governorate_id_column, output_path)
+    write_zone_summary(
+        points_gdf,
+        neighbourhood_path,
+        "neighbourhood",
+        neighbourhood_id_column,
+        output_path,
+    )
+    write_zone_summary(
+        points_gdf,
+        municipality_path,
+        "municipality",
+        municipality_id_column,
+        output_path,
+    )
+    write_zone_summary(
+        points_gdf, governorate_path, "governorate", governorate_id_column, output_path
+    )
 
     if master_grid_path is not None:
         write_master_grid_tent_count_tiff(points_gdf, master_grid_path, output_path)

--- a/displacement_tracker/paired_image_dataset.py
+++ b/displacement_tracker/paired_image_dataset.py
@@ -99,15 +99,18 @@ class PairedImageDataset(Dataset):
             return len(self.indices)
         return len(self._rows)
 
-    def _standardise(self, raster_path: str, data: np.ndarray, per_tile: bool = False) -> np.ndarray:
+    def _standardise(
+        self, raster_path: str, data: np.ndarray, per_tile: bool = False
+    ) -> np.ndarray:
         if per_tile:
             return standardise_window(
-                data, np.mean(data, axis=(1,2)), np.std(data, axis=(1,2)), None
-                )
+                data, np.mean(data, axis=(1, 2)), np.std(data, axis=(1, 2)), None
+            )
         stats = self._raster_stats.get(raster_path)
         if stats is None:
             LOGGER.warning(
-                "No stats found for raster %s; returning unstandardised data", raster_path
+                "No stats found for raster %s; returning unstandardised data",
+                raster_path,
             )
             return data.astype(np.float32, copy=False)
         return standardise_window(
@@ -121,7 +124,9 @@ class PairedImageDataset(Dataset):
         raster_h = self._get_handle(raster_path)
         window = ((row["r0"], row["r1"]), (row["c0"], row["c1"]))
         rgb_raw = raster_h.read([1, 2, 3], window=window)
-        rgb = self._standardise(raster_path, rgb_raw, per_tile=self.per_tile_standardisation)
+        rgb = self._standardise(
+            raster_path, rgb_raw, per_tile=self.per_tile_standardisation
+        )
 
         h = row["r1"] - row["r0"]
         w = row["c1"] - row["c0"]
@@ -142,10 +147,16 @@ class PairedImageDataset(Dataset):
         else:
             prewar = None
         if prewar is None:
-            LOGGER.warning("No prewar data for row %d (prewar_path=%s); using zeros", idx, prewar_path)
+            LOGGER.warning(
+                "No prewar data for row %d (prewar_path=%s); using zeros",
+                idx,
+                prewar_path,
+            )
             prewar = np.zeros((3, h, w), dtype=np.float32)
         else:
-            prewar = self._standardise(prewar_path, prewar, per_tile=self.per_tile_standardisation)
+            prewar = self._standardise(
+                prewar_path, prewar, per_tile=self.per_tile_standardisation
+            )
         feats_for_tile: list[dict[str, Any]] = []
         labels_path = row["labels_path"]
         feature_ids = row["label_feature_ids"] or []

--- a/displacement_tracker/pipelines/app.py
+++ b/displacement_tracker/pipelines/app.py
@@ -219,7 +219,7 @@ _MERMAID_FENCE = re.compile(r"```mermaid\n(.*?)```", re.DOTALL)
 def _markdown_with_mermaid(md: str) -> None:
     pos = 0
     for match in _MERMAID_FENCE.finditer(md):
-        before = md[pos:match.start()]
+        before = md[pos : match.start()]
         if before.strip():
             st.markdown(before)
         st.iframe(
@@ -250,8 +250,7 @@ def _render_load_bar(
         return f"{max(0.0, min(100.0, pct or 0.0)):.1f}"
 
     html = (
-        _LOADBAR_TEMPLATE
-        .replace("__TITLE__", title)
+        _LOADBAR_TEMPLATE.replace("__TITLE__", title)
         .replace("__CPU_CLS__", _severity(cpu_pct))
         .replace("__CPU_TEXT__", cpu_text)
         .replace("__CPU_W__", width(cpu_pct))
@@ -272,12 +271,17 @@ def _update_load_bar(box, monitor, stage_label: str) -> None:
         cpu_pct = cpu_sum / cores
         mem_pct = rss / total * 100 if total else None
         mem_text = (
-            f"{rss / 2**30:.1f} / {total / 2**30:.0f} GiB" if total
+            f"{rss / 2**30:.1f} / {total / 2**30:.0f} GiB"
+            if total
             else f"{rss / 2**30:.1f} GiB"
         )
         _render_load_bar(
-            box, f"System load — {stage_label}",
-            cpu_pct, f"{cpu_pct:.0f} %", mem_pct, mem_text,
+            box,
+            f"System load — {stage_label}",
+            cpu_pct,
+            f"{cpu_pct:.0f} %",
+            mem_pct,
+            mem_text,
         )
     except Exception:
         pass
@@ -285,21 +289,31 @@ def _update_load_bar(box, monitor, stage_label: str) -> None:
 
 def _widget(param: Param, default, key: str):
     if param.type == "bool":
-        return st.checkbox(param.label, value=bool(default), key=key, help=param.help or None)
+        return st.checkbox(
+            param.label, value=bool(default), key=key, help=param.help or None
+        )
     if param.type == "int":
         return st.number_input(
-            param.label, value=int(default if default is not None else 0),
-            step=1, key=key, help=param.help or None,
+            param.label,
+            value=int(default if default is not None else 0),
+            step=1,
+            key=key,
+            help=param.help or None,
         )
     if param.type == "float":
         return st.number_input(
-            param.label, value=float(default if default is not None else 0.0),
-            format="%g", key=key, help=param.help or None,
+            param.label,
+            value=float(default if default is not None else 0.0),
+            format="%g",
+            key=key,
+            help=param.help or None,
         )
     if param.type == "list":
         text = st.text_area(
-            param.label, value="\n".join(default or []),
-            key=key, help=param.help or None,
+            param.label,
+            value="\n".join(default or []),
+            key=key,
+            help=param.help or None,
             placeholder="Empty: scan stage processes ALL .tif files in the "
             "GeoTIFF directory; download stage downloads nothing.",
         )
@@ -307,8 +321,10 @@ def _widget(param: Param, default, key: str):
         return entries or None
     # str / path
     value = st.text_input(
-        param.label, value="" if default is None else str(default),
-        key=key, help=param.help or None,
+        param.label,
+        value="" if default is None else str(default),
+        key=key,
+        help=param.help or None,
     )
     if value == "":
         return None if param.optional else ""
@@ -332,7 +348,9 @@ def main() -> None:
         base_config_path = st.text_input("Base config", value=pipeline.base_config)
         run_root = st.text_input("Run root", value=runner.default_run_root())
         run_name = st.text_input(
-            "Run name", value="", placeholder="empty = timestamp",
+            "Run name",
+            value="",
+            placeholder="empty = timestamp",
             help="Artifacts land in <run root>/<pipeline>/<run name>/.",
         )
         st.caption("Artifacts will be written to:")
@@ -347,12 +365,16 @@ def main() -> None:
             stage
             for stage in pipeline.stages
             if st.checkbox(
-                stage.label, value=stage.default_enabled, key=f"{pipeline.key}:stage:{stage.key}"
+                stage.label,
+                value=stage.default_enabled,
+                key=f"{pipeline.key}:stage:{stage.key}",
             )
         ]
 
         run_clicked = st.button(
-            "Run pipeline", type="primary", disabled=not enabled_stages,
+            "Run pipeline",
+            type="primary",
+            disabled=not enabled_stages,
             use_container_width=True,
         )
         st.caption(
@@ -410,7 +432,9 @@ def main() -> None:
                 "Deep-merged on top of everything above. Use the same structure "
                 "as the base config, e.g. `prediction: {selection: {method: nms}}`."
             )
-            raw_yaml = st.text_area("YAML", value="", height=160, label_visibility="collapsed")
+            raw_yaml = st.text_area(
+                "YAML", value="", height=160, label_visibility="collapsed"
+            )
 
     # Fixed bottom bar (the iframe script escapes the tab flow entirely).
     load_box = st.empty()
@@ -418,7 +442,9 @@ def main() -> None:
 
     if not run_clicked:
         with logs_tab:
-            st.caption("No run in this session yet — configure and press *Run pipeline*.")
+            st.caption(
+                "No run in this session yet — configure and press *Run pipeline*."
+            )
         return
 
     extra: dict = {}
@@ -470,7 +496,9 @@ def main() -> None:
                             tail[-1] = text
                         else:
                             tail.append(text)
-                        overwrite = segment.endswith("\r") and not segment.endswith("\r\n")
+                        overwrite = segment.endswith("\r") and not segment.endswith(
+                            "\r\n"
+                        )
                         now = time.monotonic()
                         if now - last_render > 0.2:
                             box.code("\n".join(tail))
@@ -478,7 +506,9 @@ def main() -> None:
                         if now - last_load > 1.0:
                             if monitor is None and ctx.active_process is not None:
                                 try:
-                                    monitor = runner.StageLoadMonitor(ctx.active_process)
+                                    monitor = runner.StageLoadMonitor(
+                                        ctx.active_process
+                                    )
                                 except Exception:
                                     monitor = None
                             elif monitor is not None:

--- a/displacement_tracker/pipelines/cli.py
+++ b/displacement_tracker/pipelines/cli.py
@@ -29,14 +29,40 @@ def _parse_override(raw: str) -> tuple[str, object]:
 
 @click.command()
 @click.argument("pipeline_key", type=click.Choice(sorted(PIPELINES)))
-@click.option("--config", "base_config", default=None, help="Base YAML (defaults to the pipeline's standard config).")
-@click.option("--set", "assignments", multiple=True, help="Override a config value: dotted.path=value (YAML-parsed).")
-@click.option("--skip", "skipped", multiple=True, help="Stage key to skip (repeatable).")
-@click.option("--only", "only", multiple=True, help="Run only these stage keys (repeatable).")
-@click.option("--name", "run_name", default=None, help="Run name (defaults to a timestamp).")
-@click.option("--run-root", default=None, help=f"Artifact root (default: {runner.default_run_root()}).")
-@click.option("--dry-run", is_flag=True, help="Prepare the run directory and print the plan without executing.")
-def cli(pipeline_key, base_config, assignments, skipped, only, run_name, run_root, dry_run):
+@click.option(
+    "--config",
+    "base_config",
+    default=None,
+    help="Base YAML (defaults to the pipeline's standard config).",
+)
+@click.option(
+    "--set",
+    "assignments",
+    multiple=True,
+    help="Override a config value: dotted.path=value (YAML-parsed).",
+)
+@click.option(
+    "--skip", "skipped", multiple=True, help="Stage key to skip (repeatable)."
+)
+@click.option(
+    "--only", "only", multiple=True, help="Run only these stage keys (repeatable)."
+)
+@click.option(
+    "--name", "run_name", default=None, help="Run name (defaults to a timestamp)."
+)
+@click.option(
+    "--run-root",
+    default=None,
+    help=f"Artifact root (default: {runner.default_run_root()}).",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Prepare the run directory and print the plan without executing.",
+)
+def cli(
+    pipeline_key, base_config, assignments, skipped, only, run_name, run_root, dry_run
+):
     pipeline = PIPELINES[pipeline_key]
     overrides = dict(_parse_override(a) for a in assignments)
 

--- a/displacement_tracker/pipelines/runner.py
+++ b/displacement_tracker/pipelines/runner.py
@@ -156,7 +156,9 @@ def prepare_run(
     with open(config_path, "w") as f:
         yaml.safe_dump(config, f, sort_keys=False)
 
-    return RunContext(pipeline=pipeline, run_dir=run_dir, config_path=config_path, config=config)
+    return RunContext(
+        pipeline=pipeline, run_dir=run_dir, config_path=config_path, config=config
+    )
 
 
 def stage_argv(ctx: RunContext, stage: Stage) -> list[str]:

--- a/displacement_tracker/pipelines/spec.py
+++ b/displacement_tracker/pipelines/spec.py
@@ -78,22 +78,35 @@ PREDICT = Pipeline(
     base_config="config.yaml",
     stages=(
         Stage(
-            "download", "Download GeoTIFFs from Drive", "displacement_tracker.a_tif_loader",
+            "download",
+            "Download GeoTIFFs from Drive",
+            "displacement_tracker.a_tif_loader",
             default_enabled=False,
         ),
-        Stage("scan", "Scan imagery & build manifests", "displacement_tracker.b2_image_scanner"),
+        Stage(
+            "scan",
+            "Scan imagery & build manifests",
+            "displacement_tracker.b2_image_scanner",
+        ),
         Stage("predict", "Run model inference", "displacement_tracker.e_predict_json"),
-        Stage("merge", "Merge & deduplicate predictions", "displacement_tracker.h_merge_geojsons"),
+        Stage(
+            "merge",
+            "Merge & deduplicate predictions",
+            "displacement_tracker.h_merge_geojsons",
+        ),
     ),
     params=(
         Param("geotiff_dir", "GeoTIFF directory", "path", "Inputs"),
         Param(
-            "loading.files", "GeoTIFF files / search strings", "list", "Inputs",
+            "loading.files",
+            "GeoTIFF files / search strings",
+            "list",
+            "Inputs",
             optional=True,
             help="One entry per line. Download stage: entries are Drive search "
-                 "strings — if empty, the stage downloads nothing. Scan stage: "
-                 "entries are filename filters — if empty, ALL .tif files in "
-                 "the GeoTIFF directory are scanned.",
+            "strings — if empty, the stage downloads nothing. Scan stage: "
+            "entries are filename filters — if empty, ALL .tif files in "
+            "the GeoTIFF directory are scanned.",
         ),
         Param("boundaries", "Municipal boundaries (.shp)", "path", "Inputs"),
         Param("prewar_gaza", "Pre-war reference raster", "path", "Inputs"),
@@ -102,32 +115,61 @@ PREDICT = Pipeline(
         Param("processing.margin_metres", "Tile margin (m)", "int", "Processing"),
         Param(
             "processing.quality_thresholds.min_valid_fraction",
-            "Min valid fraction", "float", "Processing",
+            "Min valid fraction",
+            "float",
+            "Processing",
             help="Minimum non-black/NaN fraction for a tile to be kept.",
         ),
         Param("prediction.batch_size", "Batch size", "int", "Prediction"),
         Param("prediction.num_workers", "Data-loader workers", "int", "Prediction"),
-        Param("prediction.per_tile_standardisation", "Per-tile standardisation", "bool", "Prediction"),
+        Param(
+            "prediction.per_tile_standardisation",
+            "Per-tile standardisation",
+            "bool",
+            "Prediction",
+        ),
         Param("prediction.sample.enable", "Sample tiles only", "bool", "Prediction"),
         Param("prediction.sample.size", "Sample size", "int", "Prediction"),
         Param("prediction.sample.seed", "Sample seed", "int", "Prediction"),
-        Param("prediction.selection.threshold", "Selection threshold", "float", "Selection"),
+        Param(
+            "prediction.selection.threshold",
+            "Selection threshold",
+            "float",
+            "Selection",
+        ),
         Param("prediction.selection.factor", "Selection factor", "float", "Selection"),
         Param(
-            "prediction.selection.nms_kernel_size", "NMS kernel size (px)", "int", "Selection",
+            "prediction.selection.nms_kernel_size",
+            "NMS kernel size (px)",
+            "int",
+            "Selection",
             help="Max-pool kernel for NMS peak picking. For the 'centroid' "
-                 "method set selection.min_area via the YAML overrides instead.",
+            "method set selection.min_area via the YAML overrides instead.",
         ),
-        Param("prediction.selection.min_distance_m", "Min peak distance (m)", "float", "Selection"),
+        Param(
+            "prediction.selection.min_distance_m",
+            "Min peak distance (m)",
+            "float",
+            "Selection",
+        ),
         Param("merge.min_distance_m", "Merge distance (m)", "float", "Merge"),
         Param("merge.agreement", "Min cluster size", "int", "Merge"),
         Param("merge.min_adj_peak", "Min adjusted peak", "float", "Merge"),
         Param("merge.adjustment_factor", "Adjustment factor", "float", "Merge"),
         Param(
-            "merge.thresholds_config", "Per-file thresholds YAML", "path", "Merge",
+            "merge.thresholds_config",
+            "Per-file thresholds YAML",
+            "path",
+            "Merge",
             optional=True,
         ),
-        Param("merge.exclusion_zones_gpkg", "Exclusion zones", "path", "Merge", optional=True),
+        Param(
+            "merge.exclusion_zones_gpkg",
+            "Exclusion zones",
+            "path",
+            "Merge",
+            optional=True,
+        ),
         Param("merge.inclusion_zone", "Inclusion zone", "path", "Merge", optional=True),
     ),
     artifact_paths={
@@ -156,22 +198,35 @@ TRAIN = Pipeline(
     base_config="config.yaml",
     stages=(
         Stage(
-            "download", "Download GeoTIFFs from Drive", "displacement_tracker.a_tif_loader",
+            "download",
+            "Download GeoTIFFs from Drive",
+            "displacement_tracker.a_tif_loader",
             default_enabled=False,
         ),
-        Stage("scan", "Scan annotated imagery", "displacement_tracker.b1_annotated_scanner"),
-        Stage("rebalance", "Rebalance manifest", "displacement_tracker.c_resample_manifest"),
+        Stage(
+            "scan",
+            "Scan annotated imagery",
+            "displacement_tracker.b1_annotated_scanner",
+        ),
+        Stage(
+            "rebalance",
+            "Rebalance manifest",
+            "displacement_tracker.c_resample_manifest",
+        ),
         Stage("train", "Train CNN", "displacement_tracker.d_train_cnn"),
     ),
     params=(
         Param("geotiff_dir", "GeoTIFF directory", "path", "Inputs"),
         Param(
-            "loading.files", "GeoTIFF files / search strings", "list", "Inputs",
+            "loading.files",
+            "GeoTIFF files / search strings",
+            "list",
+            "Inputs",
             optional=True,
             help="One entry per line. Download stage: entries are Drive search "
-                 "strings — if empty, the stage downloads nothing. Scan stage: "
-                 "entries are filename filters — if empty, ALL .tif files in "
-                 "the GeoTIFF directory are scanned.",
+            "strings — if empty, the stage downloads nothing. Scan stage: "
+            "entries are filename filters — if empty, ALL .tif files in "
+            "the GeoTIFF directory are scanned.",
         ),
         Param("geojson", "Tent annotations (.geojson)", "path", "Inputs"),
         Param("boundaries", "Municipal boundaries (.shp)", "path", "Inputs"),
@@ -181,13 +236,24 @@ TRAIN = Pipeline(
         Param("processing.max_workers", "Scan workers", "int", "Processing"),
         Param(
             "processing.quality_thresholds.min_valid_fraction",
-            "Min valid fraction", "float", "Processing",
+            "Min valid fraction",
+            "float",
+            "Processing",
         ),
         Param("rebalancing.rng_seed", "Rebalancing seed", "int", "Rebalancing"),
-        Param("rebalancing.null_keep_fraction", "Null keep fraction", "float", "Rebalancing"),
         Param(
-            "training.checkpoint", "Resume checkpoint (.pth)", "path", "Training",
-            optional=True, help="Leave empty to train from scratch.",
+            "rebalancing.null_keep_fraction",
+            "Null keep fraction",
+            "float",
+            "Rebalancing",
+        ),
+        Param(
+            "training.checkpoint",
+            "Resume checkpoint (.pth)",
+            "path",
+            "Training",
+            optional=True,
+            help="Leave empty to train from scratch.",
         ),
         Param("training.device", "Device", "str", "Training"),
         Param("training.epochs", "Epochs", "int", "Training"),
@@ -214,83 +280,126 @@ TUNE = Pipeline(
     base_config="config.yaml",
     stages=(
         Stage(
-            "merge_raw", "Merge predictions (no thresholding)",
+            "merge_raw",
+            "Merge predictions (no thresholding)",
             "displacement_tracker.h_merge_geojsons",
         ),
         Stage(
-            "scan", "Scan validation & optimise thresholds",
+            "scan",
+            "Scan validation & optimise thresholds",
             "displacement_tracker.g1_scan_validation",
         ),
         Stage(
-            "merge_tuned", "Re-merge with tuned thresholds",
+            "merge_tuned",
+            "Re-merge with tuned thresholds",
             "displacement_tracker.h2_merge_tuned",
         ),
     ),
     params=(
         Param(
-            "merge.input_folder", "Prediction GeoJSONs folder", "path", "Inputs",
+            "merge.input_folder",
+            "Prediction GeoJSONs folder",
+            "path",
+            "Inputs",
             help="Predictions to tune on — typically the preds/ folder of an "
-                 "earlier prediction pipeline run.",
+            "earlier prediction pipeline run.",
         ),
         Param(
-            "tuning.master_grid", "Master grid raster", "path", "Inputs",
+            "tuning.master_grid",
+            "Master grid raster",
+            "path",
+            "Inputs",
             help="Grid the predictions and reference data are resolved onto.",
         ),
         Param(
-            "tuning.reference.type", "Reference type", "str", "Reference",
+            "tuning.reference.type",
+            "Reference type",
+            "str",
+            "Reference",
             help="vector (point annotations: GeoJSON/GPKG/SHP), unosat "
-                 "(export file or directory + date), or raster (counts "
-                 "already on the master grid).",
+            "(export file or directory + date), or raster (counts "
+            "already on the master grid).",
         ),
         Param("tuning.reference.path", "Reference data path", "path", "Reference"),
         Param(
-            "tuning.reference.date", "UNOSAT export date", "str", "Reference",
+            "tuning.reference.date",
+            "UNOSAT export date",
+            "str",
+            "Reference",
             optional=True,
             help="YYYY-MM-DD; pins one export when the path is a directory. "
-                 "Empty: the export closest to the dates stamped on the "
-                 "prediction files is auto-discovered (with a warning).",
+            "Empty: the export closest to the dates stamped on the "
+            "prediction files is auto-discovered (with a warning).",
         ),
         Param(
-            "tuning.reference.layer", "Layer", "str", "Reference",
-            optional=True, help="Layer to read from multi-layer files (GPKG/GDB).",
+            "tuning.reference.layer",
+            "Layer",
+            "str",
+            "Reference",
+            optional=True,
+            help="Layer to read from multi-layer files (GPKG/GDB).",
         ),
         Param(
-            "tuning.reference.where", "Attribute filter", "str", "Reference",
-            optional=True, help="OGR SQL filter applied to the reference features.",
+            "tuning.reference.where",
+            "Attribute filter",
+            "str",
+            "Reference",
+            optional=True,
+            help="OGR SQL filter applied to the reference features.",
         ),
         Param(
-            "tuning.metric", "Evaluation metric", "str", "Tuning",
+            "tuning.metric",
+            "Evaluation metric",
+            "str",
+            "Tuning",
             help="The optimum of this metric becomes the tuned "
-                 "(min_adj_peak, adjustment_factor) used by the final merge. "
-                 "Choices: rms, mae, rmsle, abs_total_diff, abs_total_pdiff, "
-                 "spearman.",
+            "(min_adj_peak, adjustment_factor) used by the final merge. "
+            "Choices: rms, mae, rmsle, abs_total_diff, abs_total_pdiff, "
+            "spearman.",
         ),
         Param(
-            "tuning.metrics", "Metrics to track", "list", "Tuning",
-            optional=True, help="One metric per line; the evaluation metric "
-                                "is always tracked.",
+            "tuning.metrics",
+            "Metrics to track",
+            "list",
+            "Tuning",
+            optional=True,
+            help="One metric per line; the evaluation metric is always tracked.",
         ),
         Param("tuning.factor_min", "Factor min", "float", "Tuning"),
         Param("tuning.factor_max", "Factor max", "float", "Tuning"),
         Param("tuning.cutoff_min", "Cutoff min", "float", "Tuning"),
         Param("tuning.cutoff_max", "Cutoff max", "float", "Tuning"),
         Param(
-            "tuning.ridge_probes", "Ridge probes", "int", "Tuning",
+            "tuning.ridge_probes",
+            "Ridge probes",
+            "int",
+            "Tuning",
             help="Number of factors at which the cutoff ridge is probed.",
         ),
         Param(
-            "tuning.refine_maxiter", "Refinement iterations", "int", "Tuning",
+            "tuning.refine_maxiter",
+            "Refinement iterations",
+            "int",
+            "Tuning",
             help="Max Nelder-Mead iterations for the 2-D refinement (0 disables).",
         ),
         Param(
-            "tuning.exclusion_zones", "Scan clip zones", "path", "Tuning",
+            "tuning.exclusion_zones",
+            "Scan clip zones",
+            "path",
+            "Tuning",
             optional=True,
-            help="Optional gpkg; predictions are clipped to its union "
-                 "before the scan.",
+            help="Optional gpkg; predictions are clipped to its union before the scan.",
         ),
         Param("merge.min_distance_m", "Merge distance (m)", "float", "Merge"),
         Param("merge.agreement", "Min cluster size", "int", "Merge"),
-        Param("merge.exclusion_zones_gpkg", "Exclusion zones", "path", "Merge", optional=True),
+        Param(
+            "merge.exclusion_zones_gpkg",
+            "Exclusion zones",
+            "path",
+            "Merge",
+            optional=True,
+        ),
         Param("merge.inclusion_zone", "Inclusion zone", "path", "Merge", optional=True),
     ),
     artifact_paths={

--- a/displacement_tracker/pipelines/stop.py
+++ b/displacement_tracker/pipelines/stop.py
@@ -68,7 +68,9 @@ def _with_descendants(roots: list[psutil.Process]) -> dict[int, psutil.Process]:
 @click.command()
 @click.option("--dry-run", is_flag=True, help="List what would be terminated and exit.")
 @click.option(
-    "--timeout", default=10.0, show_default=True,
+    "--timeout",
+    default=10.0,
+    show_default=True,
     help="Seconds to wait after SIGTERM before escalating to SIGKILL.",
 )
 def cli(dry_run: bool, timeout: float) -> None:
@@ -85,7 +87,9 @@ def cli(dry_run: bool, timeout: float) -> None:
     LOGGER.info(
         "%d process(es) to terminate (%d server(s), %d orphaned stage(s), "
         "rest are their children).",
-        len(targets), len(servers), len(orphans),
+        len(targets),
+        len(servers),
+        len(orphans),
     )
     if dry_run:
         return

--- a/displacement_tracker/simple_cnn.py
+++ b/displacement_tracker/simple_cnn.py
@@ -2,7 +2,6 @@ import torch
 import torch.nn as nn
 
 
-
 class SimpleCNN(nn.Module):
     ALLOWED_KWARGS = {"kernel_size", "dropout"}
 
@@ -115,7 +114,7 @@ class SimpleCNN(nn.Module):
         g = self.global_pool(x)  # (B, 8, 1, 1)
         g = self.global_fc(g)  # (B, 8, 1, 1)
         g = self.global_relu(g)
-        x = x # + g  # broadcast add  # COMMENTED OUT DELIBERATELY TO REMOVE BUG BUT KEEP COMPATIBILITY WITH TRAINED MODEL
+        x = x  # + g  # broadcast add  # COMMENTED OUT DELIBERATELY TO REMOVE BUG BUT KEEP COMPATIBILITY WITH TRAINED MODEL
 
         x = self.convend(x)
         return x

--- a/displacement_tracker/util/annotations.py
+++ b/displacement_tracker/util/annotations.py
@@ -80,5 +80,3 @@ def group_coords(
             for j in range(j_min, j_max + 1):
                 grouped[(i, j)].append(feat)
     return grouped
-
-

--- a/displacement_tracker/util/manifest_reader.py
+++ b/displacement_tracker/util/manifest_reader.py
@@ -4,6 +4,7 @@ Manifest rows are returned as plain dicts so per-row access in `__getitem__`
 doesn't depend on pyarrow at hot-path time. Memory cost: ~150 bytes per row
 × O(10^5) tiles per TIFF ≈ tens of MB — comfortable to hold in worker RAM.
 """
+
 from __future__ import annotations
 
 import json

--- a/displacement_tracker/util/manifest_writer.py
+++ b/displacement_tracker/util/manifest_writer.py
@@ -7,6 +7,7 @@ the source GeoTIFFs at training/inference time. Per-channel standardisation
 stats live in the Parquet file metadata so the dataset can normalise windows
 on the fly.
 """
+
 from __future__ import annotations
 
 import hashlib

--- a/displacement_tracker/util/raster_processing.py
+++ b/displacement_tracker/util/raster_processing.py
@@ -66,9 +66,7 @@ def _iter_chunk_windows(width: int, height: int, chunk: int):
             yield Window(col_off=col_off, row_off=row_off, width=w, height=h)
 
 
-def _accumulate_chunk_stats(
-    data: np.ndarray, nodata, sums, sumsq, counts
-) -> None:
+def _accumulate_chunk_stats(data: np.ndarray, nodata, sums, sumsq, counts) -> None:
     """Vectorised per-band sum/sumsq/count update for one chunk."""
     valid = np.isfinite(data)
     if nodata is not None:
@@ -110,7 +108,7 @@ def _stream_per_channel_stats(
 
     safe_counts = np.maximum(counts, 1)
     means = sums / safe_counts
-    var = np.maximum(0.0, sumsq / safe_counts - means ** 2)
+    var = np.maximum(0.0, sumsq / safe_counts - means**2)
     stds = np.sqrt(var)
     means[counts == 0] = 0.0
     stds[counts == 0] = 0.0
@@ -140,7 +138,9 @@ def compute_standardisation_stats(
     )
 
     # Remove last element, alpha channel
-    return means.astype(np.float32, copy=False)[:-1], stds.astype(np.float32, copy=False)[:-1]
+    return means.astype(np.float32, copy=False)[:-1], stds.astype(
+        np.float32, copy=False
+    )[:-1]
 
 
 def standardise_window(

--- a/displacement_tracker/util/reference_data.py
+++ b/displacement_tracker/util/reference_data.py
@@ -147,9 +147,7 @@ class VectorReferenceSource(PointsSource):
                 int(non_points.sum()),
             )
             gdf = gdf.assign(geometry=gdf.geometry.centroid)
-        LOGGER.info(
-            "Loaded %d reference points from %s", len(gdf), source_path
-        )
+        LOGGER.info("Loaded %d reference points from %s", len(gdf), source_path)
         super().__init__(gdf)
 
 
@@ -328,7 +326,9 @@ def _infer_type(path: str) -> str:
     )
 
 
-def build_reference_source(cfg, nearest_to: Optional[datetime] = None) -> ReferenceSource:
+def build_reference_source(
+    cfg, nearest_to: Optional[datetime] = None
+) -> ReferenceSource:
     """Build a :class:`ReferenceSource` from config.
 
     ``cfg`` is either a bare path (type inferred from the suffix) or a
@@ -365,9 +365,7 @@ def build_reference_source(cfg, nearest_to: Optional[datetime] = None) -> Refere
     accepted = {k: v for k, v in cfg.items() if k in allowed}
     dropped = sorted(set(cfg) - allowed)
     if dropped:
-        LOGGER.warning(
-            "Reference type %r ignores option(s): %s", source_type, dropped
-        )
+        LOGGER.warning("Reference type %r ignores option(s): %s", source_type, dropped)
     if nearest_to is not None and factory is UnosatReferenceSource:
         accepted["nearest_to"] = nearest_to
     return factory(path, **accepted)

--- a/displacement_tracker/util/scan_orchestrator.py
+++ b/displacement_tracker/util/scan_orchestrator.py
@@ -1,4 +1,5 @@
 """Shared per-TIFF orchestration: file collection, output layout, writer lifecycle."""
+
 from __future__ import annotations
 
 import glob
@@ -21,9 +22,7 @@ def collect_tif_files(geotiff_dir: str, params: dict | None = None) -> list[str]
     if search_files:
         all_tifs = glob.glob(os.path.join(geotiff_dir, "*.tif"))
         return [
-            p
-            for p in all_tifs
-            if any(s in os.path.basename(p) for s in search_files)
+            p for p in all_tifs if any(s in os.path.basename(p) for s in search_files)
         ]
     return glob.glob(os.path.join(geotiff_dir, "*.tif"))
 

--- a/displacement_tracker/util/tiff_predictions.py
+++ b/displacement_tracker/util/tiff_predictions.py
@@ -11,6 +11,7 @@ from displacement_tracker.util.logging_config import setup_logging
 
 LOGGER = setup_logging("tiff-predictions")
 
+
 def save_prediction_tiff(probs, bounds, out_path):
     """
     Save a single-band GeoTIFF from a probability array.

--- a/displacement_tracker/util/tile_builder.py
+++ b/displacement_tracker/util/tile_builder.py
@@ -161,9 +161,7 @@ def _read_prewar_tile(
 
         lon_c = 0.5 * (lon_min + lon_max)
         lat_c = 0.5 * (lat_min + lat_max)
-        pxs, pys = transform(
-            "EPSG:4326", prewar_src.crs, [lon_c], [lat_c]
-        )
+        pxs, pys = transform("EPSG:4326", prewar_src.crs, [lon_c], [lat_c])
         col_f, row_f = (~prewar_src.transform) * (pxs[0], pys[0])
         r_center = int(round(row_f))
         c_center = int(round(col_f))
@@ -174,9 +172,7 @@ def _read_prewar_tile(
         rpre1 = rpre0 + tile_px
         cpre1 = cpre0 + tile_px
 
-        pre_data = prewar_src.read(
-            [1, 2, 3], window=((rpre0, rpre1), (cpre0, cpre1))
-        )
+        pre_data = prewar_src.read([1, 2, 3], window=((rpre0, rpre1), (cpre0, cpre1)))
         if pre_data.size == 0:
             return None
 
@@ -190,9 +186,7 @@ def _read_prewar_tile(
                 )
             else:
                 valid_mask = (~np.isnan(prewar_tile_rgb)) & (prewar_tile_rgb != 0)
-            valid_fraction_pre = (
-                np.count_nonzero(valid_mask) / prewar_tile_rgb.size
-            )
+            valid_fraction_pre = np.count_nonzero(valid_mask) / prewar_tile_rgb.size
         except Exception:
             valid_fraction_pre = 0.0
 

--- a/displacement_tracker/util/train_metadata_embedding.py
+++ b/displacement_tracker/util/train_metadata_embedding.py
@@ -11,6 +11,7 @@ Per-row feature vector (21 dims):
 Stats are taken from PairedImageDataset's outputs, i.e. post per-TIFF
 standardization — the same signal a downstream model would consume.
 """
+
 from __future__ import annotations
 
 import datetime
@@ -186,7 +187,9 @@ class ProjectionHead(nn.Module):
         return self.net(x)
 
 
-def nt_xent_loss(z1: torch.Tensor, z2: torch.Tensor, temperature: float) -> torch.Tensor:
+def nt_xent_loss(
+    z1: torch.Tensor, z2: torch.Tensor, temperature: float
+) -> torch.Tensor:
     """SimCLR InfoNCE over in-batch negatives. z1, z2: (B, D)."""
     batch_size = z1.size(0)
     z = F.normalize(torch.cat([z1, z2], dim=0), dim=1)
@@ -269,7 +272,9 @@ def train(
     run_dir = Path("runs") / timestamp
     run_dir.mkdir(parents=True, exist_ok=True)
     save_path = (
-        Path(checkpoint_path) if checkpoint_path else (run_dir / "metadata_embedding.pth")
+        Path(checkpoint_path)
+        if checkpoint_path
+        else (run_dir / "metadata_embedding.pth")
     )
     save_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/displacement_tracker/util/validation_core.py
+++ b/displacement_tracker/util/validation_core.py
@@ -82,10 +82,7 @@ def prepare_grouped_cell_inputs(
     cols = np.asarray(cols, dtype=np.int32)
 
     in_bounds = (
-        (rows >= 0)
-        & (rows < grid_shape[0])
-        & (cols >= 0)
-        & (cols < grid_shape[1])
+        (rows >= 0) & (rows < grid_shape[0]) & (cols >= 0) & (cols < grid_shape[1])
     )
 
     pred_prepped = pred_gdf.loc[in_bounds, ["peak_value", "adjusted_peak"]].copy()

--- a/displacement_tracker/visualization/dataset_viewer.py
+++ b/displacement_tracker/visualization/dataset_viewer.py
@@ -85,9 +85,10 @@ class DatasetViewer:
         arr_feat, arr_prewar, arr_label, meta_text = self._prepare_display_data(idx)
 
         fig, axes = plt.subplots(
-            1, 3,
+            1,
+            3,
             figsize=(30, 8),  # bigger figure
-            dpi=150  # higher resolution
+            dpi=150,  # higher resolution
         )
 
         self._plot_meta(axes[0], meta_text)
@@ -114,9 +115,10 @@ class DatasetViewer:
             diff_vis /= diff_vis.max()
 
         fig, axes = plt.subplots(
-            1, 5,
+            1,
+            5,
             figsize=(30, 8),  # bigger figure
-            dpi=150  # higher resolution
+            dpi=150,  # higher resolution
         )
 
         self._plot_meta(axes[0], meta_text)


### PR DESCRIPTION
First of three stacked PRs adding a unit test suite to the repo. This one brings the codebase to a clean ruff state and adds the CI workflow that keeps it there — no test-suite content, so it can land on its own.

**Stack:** this PR → [#37 test patterns + AGENTS.md] → [#35 unit test suite]

## What's here

**The 5 pre-existing `ruff check` findings, fixed.**

Four are unused local variables (`tif_name` twice in `b_coordinate_scanner.py`, `count_loss` in `d_train_cnn.py` where the count-loss term is commented out of the return, `nodata_val` in `g1_scan_validation.py` — the other call site reads `grouped["nodata_val"]` directly and is untouched).

The fifth was a real latent bug: `count_predictions_in_tile` in `manual_eval.py` referenced an undefined `tif_path`, so it would raise `NameError` on any call. **That function is now deleted rather than repaired** — it has no callers anywhere in the repo (`main()` supersedes it with an inline `preds.within(tile_geom).sum()`), and it also leaked an unclosed rasterio dataset handle. The `NameError` was evidence it never ran; deleting removes the lint finding at its source instead of keeping 40 lines of dead duplicate alive.

**`ruff format` across the source tree.** This is the bulk of the diff (38 files) and is purely formatting — no logic touched. Doing it here means the new format gate starts green rather than failing on pre-existing drift.

**`.github/workflows/ci.yml`** running `ruff check .` and `ruff format --check .` on PRs into `main` or `Karim`. The unit test job arrives with the suite in the third PR.

## On sharing the base-branch list

An earlier revision of this PR tried to make CI and the review workflow read one shared `.github/allowed-bases.txt`. Review pushed back and the objection held up: the abstraction produced *more* copies than it removed. The list became readable from three places — the PR's merge ref (governing CI), the default branch (governing review, and not present there until the stack reaches `main`), and a hardcoded fallback that governed review in practice — where before it appeared twice. Servicing that took a gate job on every PR forever, a sparse checkout, an API read that silently fell back to a stale list on any transient failure, and a second copy of the same "is base in list" shell loop.

So it's gone. CI uses a static `branches: [main, Karim]` trigger, the review workflow is byte-identical to what it was on `Karim`, and `allowed-bases.txt` is deleted. Two short static lists with a comment pairing them beat the machinery required to share one.

## Verification

`ruff check .` and `ruff format --check .` are clean on this branch, `ci.yml` parses as valid YAML, and the formatted modules were imported to confirm the sweep is behavior-preserving (`d_train_cnn.py` byte-compiled instead, since torch isn't installed in the verification environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQjxWgZ242WWfxZhv6JPJ2