### PR TITLE
Document test conventions in docs/test-patterns.md, pointed at by AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Working in this repository
+
+Guidance for coding agents (and humans) making changes to TentNetFA — a
+pipeline that detects tents in Gaza Strip satellite imagery to support
+displacement nowcasting. See `README.md` for what the project does and how to
+run it end to end.
+
+## Layout
+
+| Path | Contents |
+|---|---|
+| `displacement_tracker/` | All source. Stage modules are ordered by pipeline position (`a_tif_loader`, `b2_image_scanner`, … `h_merge_geojsons`, `i_zonal_point_sums`). |
+| `displacement_tracker/util/` | Shared logic: config resolution, thresholding, deduplication, reference data, validation. |
+| `displacement_tracker/pipelines/` | Pipeline specs and the two frontends (Streamlit UI, `pipeline-run` CLI) that render from them. |
+| `displacement_tracker/evaluation/` | The standalone analysis suite scoring predictions against manual annotations. |
+| `tests/` | Unit tests. **See [`docs/test-patterns.md`](docs/test-patterns.md) before adding any.** |
+| `config.yaml` | Single config for every flow, in `shared` / `train` / `predict` / `tune` sections. |
+
+## Commands
+
+```bash
+poetry install                  # set up
+poetry run pytest tests/ -q     # unit tests
+poetry run ruff check .         # lint
+poetry run ruff format .        # format
+poetry run pipeline-run tune --dry-run   # resolve a flow without running it
+```
+
+CI runs the tests, `ruff check`, and `ruff format --check` on every pull
+request into `main` or `Karim`, and all three must be green. That base list
+lives in the `pull_request` trigger of `.github/workflows/ci.yml`; the
+thermo-nuclear review workflow keeps its own copy in `ALLOWED_BASES`, so a
+new base branch has to be added in both.
+
+## Conventions
+
+- **Tests: read [`docs/test-patterns.md`](docs/test-patterns.md) first.** It
+  is binding. In short: the suite is a refactoring safety net for
+  deterministic pipeline behavior, so test genuine business logic only,
+  annotate every test with Given/When/Then comments split inline above the
+  code each describes, use real files in `tmp_path` instead of mocks, and
+  derive expected values by hand. A test that cannot fail for a real
+  behavioral reason does not belong in the suite.
+- **Config over flags.** Stages read their settings from a section of
+  `config.yaml` resolved through `util/config.py`; `shared` holds anything
+  more than one flow needs. Prefer adding a config key over adding a CLI
+  flag, and keep function-signature defaults as the single source of truth
+  for values the config does not set.
+- **Pipelines are declarative.** `pipelines/spec.py` describes stages,
+  parameters, and artifact paths; both frontends render from it. Adding a
+  stage or a parameter means editing the spec, not the UI.
+- **Match the surrounding code** in naming, structure, and comment density.
+  Comment to record a constraint the code cannot express — not to narrate
+  what the next line does.
+- **Keep the repo small.** Imagery, model checkpoints, and generated results
+  stay out of git; `.gitignore` covers the known output directories. Document
+  where large inputs come from instead of committing them.

--- a/docs/test-patterns.md
+++ b/docs/test-patterns.md
@@ -1,0 +1,224 @@
+# Test patterns
+
+Conventions for everything under `tests/`. These are requirements, not
+suggestions: a test that breaks them should be rewritten or deleted rather
+than merged.
+
+## 0. What this suite is for
+
+It is a refactoring safety net. Its job is to pin the **deterministic**
+behavior of the pipelines — the input-to-output contracts that must survive
+any future restructuring of the code that implements them.
+
+That purpose sets the boundary in both directions:
+
+- **Only deterministic behavior is constrained.** Given the same inputs, the
+  behavior under test must produce the same result on every machine and every
+  run. Anything whose output depends on wall-clock time, a random draw, model
+  training, floating-point noise beyond a stated tolerance, or the contents of
+  a data share is out of scope — a test that pins it will either be flaky or
+  be silently weakened until it stops catching anything. Where a computation
+  is seeded and reproducible, it is fair game; where it is genuinely random,
+  test the surrounding logic that *is* deterministic.
+- **Only behavior worth preserving is constrained.** Pin the contract, not
+  the implementation. A test should survive a rewrite of the internals that
+  keeps the observable behavior intact, and fail the moment that behavior
+  changes. Tests that reach into private helpers or restate the source line
+  by line make refactoring harder, which is the opposite of the point.
+
+## 1. Test genuine business logic only
+
+A test earns its place by failing when the pipeline would produce a wrong
+answer for a real user. Business logic here means the code that decides
+*what the numbers are*:
+
+- algorithms and numeric computation — thresholding, deduplication,
+  distances, error statistics, grid aggregation;
+- selection and filtering semantics — which points survive a threshold,
+  which reference export pairs with which predictions, which rows a date
+  filter keeps;
+- configuration resolution — precedence between defaults, config sections,
+  overrides, and forced invariants;
+- validation and error rules — what raises, and whether the message names
+  the thing the user has to fix;
+- parsing of names, dates, and paths that drive the above.
+
+**Do not test:**
+
+- logging output, progress reporting, or plot rendering;
+- click flag plumbing — test the function the CLI calls instead. (Driving a
+  CLI is fine when the behavior under test *only* exists there, such as
+  config resolution across sections; the test must then assert the resulting
+  behavior, not that a flag was parsed.)
+- trivial pass-throughs, `__repr__`, or constants restated from the source;
+- anything whose only failure mode is "the mock wasn't called".
+
+Ask of every test: **what bug does this catch?** If the honest answer is
+"none that could plausibly be written", delete it. A smaller suite of sharp
+tests beats a large one that reports green through real regressions.
+
+## 2. Given / When / Then, split inline
+
+Every test is annotated with three comments, each sitting **directly above
+the code it describes**, separated by a blank line:
+
+```python
+def test_points_closer_than_the_threshold_merge_into_one():
+    # Given: two detections 2 m apart, inside the 3 m merge radius
+    points = [(31.5000000, 34.5, 0.9, 0.9), (31.5000180, 34.5, 0.4, 0.4)]
+
+    # When: they are merged with a 3 m radius and no agreement requirement
+    merged = merge_close_points_global(points, min_distance_m=3.0, agreement=1)
+
+    # Then: they collapse to a single point at the midpoint, carrying the
+    #       higher peak
+    assert len(merged) == 1
+    assert merged[0][0] == pytest.approx(31.5000090)
+    assert merged[0][2] == pytest.approx(0.9)
+```
+
+Rules:
+
+- **Given** describes the fixture and the properties that matter — the
+  distances, counts, and CRSs the expectation depends on — not a restatement
+  of the code beneath it.
+- **When** names the call under test. Exactly one action; if a test needs two,
+  see the multi-phase form below.
+- **Then** states the expected outcome *and the reasoning behind a
+  non-obvious number*, so a reader can check the expectation without
+  re-deriving it.
+- Continuation lines align under the first word after the label.
+- The comments must stay **truthful**: if the code changes, the prose changes
+  with it. A stale Given/When/Then is a defect.
+
+For a test whose action is a single expression, bind it to a name so the
+three phases remain distinct:
+
+```python
+def test_compact_date_in_a_file_name_is_parsed():
+    # Given: an export file name carrying a compact YYYYMMDD date
+    path = "/data/exports/UNOSAT_20240103_shelters.gpkg"
+
+    # When: the date is extracted from the name
+    parsed = extract_date_from_filename(path)
+
+    # Then: it resolves to that calendar date
+    assert parsed == datetime(2024, 1, 3)
+```
+
+A test that exercises the same behavior across several inputs keeps one set
+of labels and loops inside the **When/Then** section. A test that genuinely
+needs two actions — typically a contrasting case that would otherwise be a
+near-duplicate — repeats the **When/Then** pair under the shared **Given**,
+each above its own block.
+
+When the action is expected to raise, `pytest.raises` fuses the call and the
+assertion into one statement, so the two labels sit together above the
+`with` line — When naming the call, Then describing the failure and the part
+of the message that must appear:
+
+```python
+def test_a_two_date_csv_requires_an_explicit_date(tmp_path):
+    # Given: a CSV holding annotations for two acquisition dates
+    csv = write_csv(tmp_path / "ann.csv", ["2024-10-14,...", "2024-11-01,..."])
+
+    # When: a reference source is built without naming a date
+    # Then: it refuses, listing both dates the caller can choose from
+    with pytest.raises(ValueError, match=r"2024-10-14.*2024-11-01"):
+        ManualAnnotationReferenceSource(csv)
+```
+
+Do not contort a test to avoid this — binding `excinfo` and asserting
+below it only to separate the labels adds an assertion without adding
+coverage.
+
+## 3. No mocks
+
+`unittest.mock`, `MagicMock`, and patching the code under test are not used.
+
+`monkeypatch` is permitted for one purpose: **cutting the test off from the
+ambient environment**, so the result does not depend on the machine it runs
+on. Setting or clearing an environment variable qualifies; so does stubbing
+`load_dotenv` in a function that would otherwise read a developer's local
+`.env`. The line is that you may neutralise the environment a behavior reads
+from — never the behavior itself.
+
+Where code touches the filesystem, build **real files in `tmp_path`** —
+GeoJSON, GPKG, GeoTIFF, YAML, CSV, Parquet. Reading a real file back is real
+behavior; a mocked reader only tests the mock. Fixtures stay small enough to
+reason about: a handful of points, a 3×3 grid, two dates.
+
+Passing a plain function or lambda where the code under test takes a callable
+is not mocking — that is the function's real parameter contract.
+
+## 4. Derive expectations by hand
+
+Compute the expected value yourself from the definition of the behavior, on
+inputs small enough to work through exactly. **Never** paste the
+implementation's own output back in as the expectation — that locks in
+whatever the code does today, including its bugs.
+
+Where a value is exactly computable, assert it with `pytest.approx` and a
+tight tolerance. Where two independent derivations exist (say a closed form
+and a geometric argument), agreeing on both is good evidence the expectation
+is right.
+
+## 5. Assert sharply
+
+Every assertion should be able to fail for a real behavioral reason:
+
+- `len(result) > 0`, `assert result is not None`, and bare `isinstance`
+  checks are almost never enough — assert *which* elements survived and what
+  they contain;
+- pin the specific cell, coordinate, or key the logic is responsible for, not
+  just the aggregate;
+- a tolerance wide enough that any plausible answer passes is not a test;
+- when asserting an error, match the part of the message that names what the
+  user must fix.
+
+A useful check while writing: perturb the expectation or an input and confirm
+the test fails. If it still passes, it is not testing what its name claims.
+
+## 6. Structure
+
+- Plain `pytest` functions, named for the behavior they pin
+  (`test_<subject>_<expected behavior>`), not the function they call.
+- **Test logic stays in its own file.** Reading one file top to bottom should
+  tell you what is being pinned and why, without chasing indirection.
+- **Shared machinery does not.** Builders that encode an on-disk format or a
+  domain schema — the GeoJSON/GPKG/GeoTIFF/YAML/CSV writers, the CRS
+  constants and coordinate transformers — live in `tests/_helpers.py` and are
+  imported explicitly:
+
+  ```python
+  from _helpers import CRS_UTM, write_geojson
+  ```
+
+  Copying such a builder into a second test file duplicates a contract, and
+  the copies drift: an annotation-CSV header written out in two places is two
+  places to update and one place to forget. Explicit imports keep the
+  dependency visible, which implicit fixture injection would not.
+- `tests/conftest.py` is for cross-cutting *fixtures* only — isolating global
+  state so tests cannot leak into one another, and pinning the matplotlib
+  backend. It is not a dumping ground for helpers, and nothing in it should
+  encode what a test expects.
+- Group related tests under a comment banner naming the area under test.
+- Tests must pass in any order — no reliance on execution order or on state
+  left by another test or file. Watch for module-level registries and
+  caches that an import mutates: those leak across files, and the fix is to
+  isolate the state in a fixture, never to loosen the assertion until it
+  tolerates both orderings.
+
+## 7. Running them
+
+```bash
+poetry run pytest tests/ -q     # the suite
+poetry run ruff check .         # lint
+poetry run ruff format .        # formatting
+```
+
+CI runs all three on every pull request into `main` or `Karim` (see
+`.github/workflows/ci.yml`). Tests install from `requirements-test.txt`, a
+pinned subset that deliberately excludes the torch/selenium/opencv stack —
+if a test needs one of those, it is an integration test and does not belong
+in this suite.


### PR DESCRIPTION
Documents the conventions the unit test suite is written to. Two new files, no code changes. Rebased onto `Karim` now that #36 has merged, so the diff is just the docs.

## `docs/test-patterns.md`

Binding conventions for everything under `tests/`, organised around what the suite is *for*.

**It is a refactoring safety net.** Its job is to pin the deterministic behavior of the pipelines — the input-to-output contracts that must survive future restructuring. That purpose draws the boundary in both directions:

- **Only deterministic behavior is constrained.** Anything depending on wall-clock time, an unseeded random draw, model training, or the contents of a data share is out of scope; pinning it produces tests that are flaky or get quietly weakened until they catch nothing.
- **Only behavior worth preserving is constrained.** Pin the contract, not the implementation, so a test survives an internals rewrite and fails the moment observable behavior changes.

From there:

1. **Genuine business logic only** — algorithms, selection and filtering semantics, config resolution, validation rules. Explicitly not: logging, plot rendering, click flag plumbing, or anything whose only failure mode is "the mock wasn't called". The test to apply is *what bug does this catch?*
2. **Given/When/Then split inline**, each label directly above the code it describes rather than stacked at the top — with worked examples for the awkward shapes: single-expression tests, loops, genuinely two-phase tests, and `pytest.raises` (where the call and the assertion are one statement, so the two labels sit together).
3. **No mocks** — real files in `tmp_path`. `monkeypatch` is permitted for one purpose: cutting a test off from the ambient environment, so a result never depends on the machine it runs on. Never for stubbing the code under test.
4. **Hand-derived expectations** — never paste the implementation's own output back in, since that locks in today's bugs.
5. **Sharp assertions** — pin the specific cell, coordinate, or key; match the part of an error message that names what the user must fix.
6. **Structure** — test logic stays in its file; shared on-disk-format builders live in `tests/_helpers.py` and are imported explicitly; `conftest.py` is for cross-cutting fixtures only. Tests must pass in any order, and the fix for a leaking module-level registry is to isolate it in a fixture, never to loosen the assertion until it tolerates both orderings.

## `AGENTS.md`

Repo-level guide for coding agents at the conventional root location: source layout, the commands that matter, and standing conventions (config over flags, declarative pipeline specs, keeping large data out of git) — with the test patterns called out as binding for anything under `tests/`.

## Two notes

**Forward references.** Both documents describe the suite that arrives in #35, so `tests/`, `_helpers.py` and `requirements-test.txt` are named before they exist. That is deliberate — the standard is reviewed before the code written to it.

**These rules were revised by review, not just drafted.** The first version said "each file is self-contained: no `conftest.py`". Reviewing #35 against it showed that rule was itself the cause of duplicated fixture builders — `write_geojson` copied verbatim, the annotation-CSV header encoded independently twice, GeoTIFF boilerplate twice. The structure rule now separates test logic from shared machinery, and the mocking rule was widened from "environment variables" to environment isolation generally, after a test proved non-hermetic because `load_dotenv()` repopulated a variable it had cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQjxWgZ242WWfxZhv6JPJ2