### PR TITLE
Tests for config resolution and pipeline specs (5/6)

### DIFF
--- a/tests/test_config_flows.py
+++ b/tests/test_config_flows.py
@@ -1,0 +1,262 @@
+"""Tests for displacement_tracker.util.config: dotted-path helpers, deep
+merging, and sectioned shared/per-flow config resolution."""
+
+import click
+import pytest
+
+from displacement_tracker.util.config import (
+    deep_get,
+    deep_merge,
+    deep_set,
+    is_sectioned_config,
+    load_flow_config,
+    resolve_flow_config,
+)
+
+
+def test_deep_get_returns_nested_value():
+    # Given: a three-level nested dict with value 7 at a.b.c
+    cfg = {"a": {"b": {"c": 7}}}
+
+    # When: deep_get is asked for the dotted path "a.b.c" and for "a.b"
+    leaf = deep_get(cfg, "a.b.c")
+    branch = deep_get(cfg, "a.b")
+
+    # Then: it returns 7, and a one-level path returns the intermediate dict
+    assert leaf == 7
+    assert branch == {"c": 7}
+
+
+def test_deep_get_missing_or_non_dict_returns_default():
+    # Given: a dict where "a.b" is a scalar and "x" does not exist
+    cfg = {"a": {"b": 5}, "lst": [1, 2]}
+
+    # When: deep_get traverses a missing key or descends through a non-dict
+    absent_root = deep_get(cfg, "x", default="dflt")
+    through_scalar = deep_get(cfg, "a.b.c", default=-1)  # 5 is not a dict
+    into_list = deep_get(cfg, "lst.0")  # lists are not traversed
+    absent_leaf = deep_get(cfg, "a.missing", default=0)
+
+    # Then: the supplied default is returned instead of raising
+    assert absent_root == "dflt"
+    assert through_scalar == -1
+    assert into_list is None
+    assert absent_leaf == 0
+
+
+def test_deep_set_creates_intermediate_dicts():
+    # Given: an empty config dict
+    cfg = {}
+
+    # When: deep_set writes value 1 at dotted path "a.b.c"
+    deep_set(cfg, "a.b.c", 1)
+
+    # Then: all intermediate dicts are created and the leaf holds 1
+    assert cfg == {"a": {"b": {"c": 1}}}
+
+
+def test_deep_set_replaces_non_dict_intermediates():
+    # Given: a config where "a" is a scalar (5)
+    cfg = {"a": 5, "keep": True}
+
+    # When: deep_set writes at "a.b", which needs "a" to be a dict
+    deep_set(cfg, "a.b", 2)
+
+    # Then: the scalar is replaced by a fresh dict holding the leaf
+    assert cfg == {"a": {"b": 2}, "keep": True}
+
+
+def test_deep_merge_nested_extra_wins_and_mutates_base():
+    # Given: base and extra sharing the nested key m.x with different values
+    base = {"m": {"x": 1, "y": 2}, "only_base": "b"}
+    extra = {"m": {"x": 10, "z": 3}, "only_extra": "e"}
+
+    # When: deep_merge(base, extra) runs
+    result = deep_merge(base, extra)
+
+    # Then: extra's m.x wins, base-only keys survive at every level, and the
+    #       returned object is the mutated base itself
+    assert result is base
+    assert base == {
+        "m": {"x": 10, "y": 2, "z": 3},
+        "only_base": "b",
+        "only_extra": "e",
+    }
+
+
+def test_deep_merge_type_conflicts_extra_always_wins():
+    # Given: base has a dict where extra has a scalar, and vice versa
+    base = {"a": {"nested": 1}, "b": 2}
+    extra = {"a": "scalar", "b": {"now": "dict"}}
+
+    # When: deep_merge runs
+    deep_merge(base, extra)
+
+    # Then: extra's value replaces base's wholesale in both directions
+    assert base == {"a": "scalar", "b": {"now": "dict"}}
+
+
+def test_is_sectioned_config_detection():
+    # Given: dicts with and without shared/train/predict/tune top-level keys,
+    #        plus a value that is not a dict at all
+    shared_marked = {"shared": {}}
+    tune_marked = {"tune": {"a": 1}}
+    flat = {"geotiff_dir": "/x", "merge": {}}
+
+    # When: is_sectioned_config inspects each of them
+    shared_result = is_sectioned_config(shared_marked)
+    tune_result = is_sectioned_config(tune_marked)
+    flat_result = is_sectioned_config(flat)
+    non_dict_result = is_sectioned_config("not a dict")
+
+    # Then: any section key marks it sectioned; flat configs and non-dicts
+    #       are not sectioned
+    assert shared_result is True
+    assert tune_result is True
+    assert flat_result is False
+    assert non_dict_result is False
+
+
+def test_resolve_flat_config_passes_through_unchanged():
+    # Given: a legacy flat config (no section keys)
+    cfg = {"geotiff_dir": "/data", "merge": {"agreement": 2}}
+
+    # When: resolve_flow_config is called with a flow, and with None
+    with_flow = resolve_flow_config(cfg, "predict")
+    without_flow = resolve_flow_config(cfg, None)
+
+    # Then: the very same object is returned untouched
+    assert with_flow is cfg
+    assert without_flow is cfg
+    assert cfg == {"geotiff_dir": "/data", "merge": {"agreement": 2}}
+
+
+def test_resolve_sectioned_flow_wins_over_shared():
+    # Given: shared defines processing.core=100 and boundaries; the predict
+    #        section overrides processing.core=50 and adds a model key
+    cfg = {
+        "shared": {
+            "boundaries": "/b.shp",
+            "processing": {"core": 100, "margin": 10},
+        },
+        "predict": {"model": "/m.pth", "processing": {"core": 50}},
+        "train": {"epochs": 3},
+    }
+
+    # When: resolving flow "predict"
+    resolved = resolve_flow_config(cfg, "predict")
+
+    # Then: the flat result deep-merges predict over shared — core=50,
+    #       shared-only keys (margin, boundaries) survive, and no section
+    #       names appear in the output
+    assert resolved == {
+        "boundaries": "/b.shp",
+        "processing": {"core": 50, "margin": 10},
+        "model": "/m.pth",
+    }
+    assert "shared" not in resolved and "train" not in resolved
+
+
+def test_resolve_sectioned_returns_deep_copies():
+    # Given: a sectioned config with a nested dict in shared
+    cfg = {
+        "shared": {"processing": {"core": 100}},
+        "tune": {"tuning": {"metric": "rms"}},
+    }
+
+    # When: the tune flow is resolved and the result is mutated afterwards
+    resolved = resolve_flow_config(cfg, "tune")
+    resolved["processing"]["core"] = -1
+    resolved["tuning"]["metric"] = "mae"
+
+    # Then: the original shared/flow sections are unaffected (deep copies)
+    assert cfg["shared"]["processing"]["core"] == 100
+    assert cfg["tune"]["tuning"]["metric"] == "rms"
+
+
+def test_resolve_rejects_mixed_sectioned_and_stray_keys():
+    # Given: a half-migrated config with a "shared" section plus stray
+    #        top-level keys "zeta" and "alpha"
+    cfg = {"shared": {}, "predict": {}, "zeta": 1, "alpha": 2}
+
+    # When: resolving any flow
+    # Then: click.UsageError names the stray keys in sorted order
+    with pytest.raises(click.UsageError, match="alpha, zeta"):
+        resolve_flow_config(cfg, "predict")
+
+
+def test_resolve_sectioned_without_flow_raises():
+    # Given: a valid sectioned config
+    cfg = {"shared": {}, "predict": {"a": 1}}
+
+    # When: resolve_flow_config is called with flow=None
+    # Then: click.UsageError asks for --flow
+    with pytest.raises(click.UsageError, match="--flow"):
+        resolve_flow_config(cfg, None)
+
+
+def test_resolve_unknown_flow_raises():
+    # Given: a sectioned config and a flow name outside FLOWS
+    cfg = {"shared": {}, "predict": {"a": 1}}
+
+    # When: resolving flow "evaluate"
+    # Then: click.UsageError reports the unknown flow name
+    with pytest.raises(click.UsageError, match="evaluate"):
+        resolve_flow_config(cfg, "evaluate")
+
+
+def test_resolve_missing_flow_section_raises():
+    # Given: a sectioned config that has predict but no train section
+    cfg = {"shared": {"a": 1}, "predict": {"b": 2}}
+
+    # When: resolving flow "train" (a valid flow name)
+    # Then: click.UsageError reports the missing 'train' section
+    with pytest.raises(click.UsageError, match="no 'train' section"):
+        resolve_flow_config(cfg, "train")
+
+
+def test_resolve_handles_null_shared_and_null_flow_sections():
+    # Given: YAML-style empty sections parse to None — one config with
+    #        shared: null, another with an empty tune: section
+    null_shared = {"shared": None, "tune": {"a": 1}}
+    null_flow = {"shared": {"b": 2}, "tune": None}
+
+    # When: resolving the tune flow in each
+    from_null_shared = resolve_flow_config(null_shared, "tune")
+    from_null_flow = resolve_flow_config(null_flow, "tune")
+
+    # Then: null shared resolves to just the flow section, and a null flow
+    #       section resolves to just shared (no crash on None)
+    assert from_null_shared == {"a": 1}
+    assert from_null_flow == {"b": 2}
+
+
+def test_load_flow_config_reads_yaml_substitutes_env_and_resolves(
+    tmp_path, monkeypatch
+):
+    # Given: a real sectioned YAML file referencing ${TENTNET_TEST_DATA} in
+    #        shared, with a train section overriding batch_size, and the env
+    #        var set
+    monkeypatch.setenv("TENTNET_TEST_DATA", "/mnt/data")
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(
+        "shared:\n"
+        "  geotiff_dir: ${TENTNET_TEST_DATA}/tifs\n"
+        "  training:\n"
+        "    batch_size: 8\n"
+        "train:\n"
+        "  training:\n"
+        "    batch_size: 32\n"
+        "predict:\n"
+        "  model: m.pth\n"
+    )
+
+    # When: load_flow_config loads it for flow "train"
+    resolved = load_flow_config(str(cfg_file), "train")
+
+    # Then: the env var is substituted into the value and the train section
+    #       is deep-merged over shared (train's batch_size wins)
+    assert resolved == {
+        "geotiff_dir": "/mnt/data/tifs",
+        "training": {"batch_size": 32},
+    }

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -1,0 +1,379 @@
+"""Tests for the pipeline specs (displacement_tracker.pipelines.spec) and
+the run preparation logic (displacement_tracker.pipelines.runner).
+
+prepare_run's config layering contract:
+    extra_defaults < resolved base config < overrides < forced_values,
+with artifact_paths forced into the run directory last.
+"""
+
+import os
+import sys
+
+import pytest
+import yaml
+
+from displacement_tracker.pipelines.runner import (
+    default_run_root,
+    prepare_run,
+    stage_argv,
+)
+from displacement_tracker.pipelines.spec import PREDICT, TRAIN, TUNE, Pipeline
+
+
+def _make_pipeline(**kwargs) -> Pipeline:
+    defaults = dict(
+        key="predict",
+        label="Test pipeline",
+        base_config="config.yaml",
+        stages=(),
+        params=(),
+    )
+    defaults.update(kwargs)
+    return Pipeline(**defaults)
+
+
+def test_subfolders_take_first_path_component_plus_logs():
+    # Given: artifact paths "manifests", "dataset/balanced.parquet",
+    #        "dataset/other.bin" and "deep/a/b"
+    p = _make_pipeline(
+        artifact_paths={
+            "a": "manifests",
+            "b": "dataset/balanced.parquet",
+            "c": "dataset/other.bin",
+            "d": "deep/a/b",
+        }
+    )
+
+    # When: Pipeline.subfolders derives the fixed run-dir subfolders
+    subfolders = p.subfolders
+
+    # Then: each relative path contributes only its first component,
+    #       duplicates collapse, "logs" is always included, sorted output
+    assert subfolders == ["dataset", "deep", "logs", "manifests"]
+
+
+def test_prepare_run_layering_defaults_base_overrides_forced(tmp_path):
+    # Given: a pipeline with extra_defaults sec={a:1,b:2,d:4}, forced
+    #        sec.b=99, and a flat base config sec={b:5,c:7} plus other=keep
+    pipeline = _make_pipeline(
+        extra_defaults={"sec": {"a": 1, "b": 2, "d": 4}},
+        forced_values={"sec.b": 99},
+    )
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"sec": {"b": 5, "c": 7}, "other": "keep"}))
+
+    # When: prepare_run applies overrides {sec.c:8, sec.d:40, new.deep.key:True}
+    ctx = prepare_run(
+        pipeline,
+        base,
+        overrides={"sec.c": 8, "sec.d": 40, "new.deep.key": True},
+        run_name="run1",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: each key lands at its layer — a=1 (default only), b=99 (forced
+    #       beats base's 5), c=8 (override beats base's 7), d=40 (override
+    #       beats default's 4), other survives, and the dotted override
+    #       created the nested "new" structure
+    assert ctx.config["sec"] == {"a": 1, "b": 99, "c": 8, "d": 40}
+    assert ctx.config["other"] == "keep"
+    assert ctx.config["new"] == {"deep": {"key": True}}
+    # The written config.yaml is the same resolved config, read back for real.
+    with open(ctx.config_path) as f:
+        assert yaml.safe_load(f) == ctx.config
+
+
+def test_prepare_run_tune_invariants_survive_poisoned_config_and_overrides(tmp_path):
+    # Given: a sectioned base config whose shared and tune sections poison
+    #        the merge thresholds (min_adj_peak 0.9, adjustment_factor 5.0,
+    #        thresholds_config set)
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "shared": {"merge": {"min_adj_peak": 0.9}},
+                "predict": {"model": "m.pth"},
+                "tune": {
+                    "merge": {
+                        "adjustment_factor": 5.0,
+                        "thresholds_config": "/poison.yaml",
+                        "agreement": 2,
+                    },
+                    "tuning": {"metric": "mae"},
+                },
+            }
+        )
+    )
+
+    # When: prepare_run builds a TUNE run with overrides poisoning the same
+    #       thresholds again
+    ctx = prepare_run(
+        TUNE,
+        base,
+        overrides={
+            "merge.min_adj_peak": 0.5,
+            "merge.adjustment_factor": 9.0,
+            "merge.thresholds_config": "/still_poison.yaml",
+            "merge.agreement": 4,
+        },
+        run_name="tune_run",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: the config written to disk still carries the forced invariants —
+    #       min_adj_peak 0.0, adjustment_factor 1.0, thresholds_config null —
+    #       while non-forced merge keys keep their override/base values
+    with open(ctx.config_path) as f:
+        written = yaml.safe_load(f)
+    assert written["merge"]["min_adj_peak"] == pytest.approx(0.0)
+    assert written["merge"]["adjustment_factor"] == pytest.approx(1.0)
+    assert written["merge"]["thresholds_config"] is None
+    # Non-forced keys follow normal precedence: override wins over base.
+    assert written["merge"]["agreement"] == 4
+    # Sectioned resolution happened: flat config, no section keys, no
+    # leakage from the predict section.
+    assert "shared" not in written and "predict" not in written
+    assert "model" not in written
+
+
+def test_prepare_run_extra_defaults_fill_gaps_but_never_override(tmp_path):
+    # Given: a flat tune-style base config that sets merge.min_distance_m=7.5
+    #        and tuning.metric=mae but omits the other merge/tuning keys
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "merge": {"min_distance_m": 7.5},
+                "tuning": {"metric": "mae"},
+            }
+        )
+    )
+
+    # When: prepare_run builds a TUNE run with no overrides
+    ctx = prepare_run(TUNE, base, run_name="r", run_root=tmp_path / "runs")
+
+    # Then: explicit base values survive (7.5, mae) while absent keys are
+    #       filled from TUNE.extra_defaults (agreement 1, ridge_probes 5,
+    #       cutoff_min 0.0001, reference.type "vector")
+    cfg = ctx.config
+    assert cfg["merge"]["min_distance_m"] == pytest.approx(7.5)
+    assert cfg["merge"]["agreement"] == 1
+    assert cfg["tuning"]["metric"] == "mae"
+    assert cfg["tuning"]["ridge_probes"] == 5
+    assert cfg["tuning"]["cutoff_min"] == pytest.approx(1.0e-4)
+    assert cfg["tuning"]["reference"] == {"type": "vector"}
+
+
+def test_prepare_run_forces_artifact_paths_into_run_dir(tmp_path):
+    # Given: a TUNE base config and an override that points merge.output
+    #        somewhere outside the run directory
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"tune": {"tuning": {"metric": "rms"}}}))
+    run_root = tmp_path / "runs"
+
+    # When: prepare_run builds the run
+    ctx = prepare_run(
+        TUNE,
+        base,
+        overrides={"merge.output": "/elsewhere/out.gpkg"},
+        run_name="myrun",
+        run_root=run_root,
+    )
+
+    # Then: every artifact path is rewritten to the fixed location inside
+    #       <run_root>/tune/<run_name>, the fixed subfolders exist on disk,
+    #       and the resolved config lands at <run_dir>/config.yaml
+    run_dir = run_root / "tune" / "myrun"
+    assert ctx.run_dir == run_dir
+    assert ctx.config_path == run_dir / "config.yaml"
+    assert ctx.config_path.is_file()
+    assert ctx.config["merge"]["output"] == str(run_dir / "merged_raw/merged_raw.gpkg")
+    assert ctx.config["tuning"]["out_dir"] == str(run_dir / "tuning")
+    assert ctx.config["tuning"]["best_params"] == str(
+        run_dir / "tuning/best_params.yaml"
+    )
+    assert ctx.config["tuning"]["final_output"] == str(
+        run_dir / "merged/merged_tuned.gpkg"
+    )
+    for sub in ("logs", "merged", "merged_raw", "tuning"):
+        assert (run_dir / sub).is_dir()
+
+
+def test_prepare_run_does_not_mutate_the_pipeline_spec(tmp_path):
+    # Given: the shared TUNE spec and a tune base config
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"tune": {"tuning": {"metric": "rms"}}}))
+
+    # When: prepare_run applies overrides that write into paths whose values
+    #       originate from extra_defaults (tuning.reference.type)
+    prepare_run(
+        TUNE,
+        base,
+        overrides={"tuning.reference.type": "raster", "merge.agreement": 12},
+        run_name="first",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: TUNE.extra_defaults is untouched
+    assert TUNE.extra_defaults["tuning"]["reference"] == {"type": "vector"}
+    assert TUNE.extra_defaults["merge"]["agreement"] == 1
+
+    # When: a second run is prepared without overrides
+    ctx2 = prepare_run(TUNE, base, run_name="second", run_root=tmp_path / "runs")
+
+    # Then: it still gets the pristine defaults
+    assert ctx2.config["tuning"]["reference"]["type"] == "vector"
+    assert ctx2.config["merge"]["agreement"] == 1
+
+
+def test_prepare_run_predict_fills_documented_merge_defaults(tmp_path):
+    # Given: a minimal flat base config with no merge section at all
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"geotiff_dir": "/tifs"}))
+
+    # When: prepare_run builds a PREDICT run with no overrides
+    ctx = prepare_run(PREDICT, base, run_name="r", run_root=tmp_path / "runs")
+
+    # Then: the resolved config carries exactly the documented merge
+    #       defaults — min_distance_m 3.0, agreement 1 (single-model runs
+    #       keep every point), min_adj_peak 0.0, adjustment_factor 1.0,
+    #       and null thresholds_config / exclusion_zones_gpkg /
+    #       inclusion_zone — plus merge.output, which is artifact-forced
+    #       into the run directory rather than defaulted
+    merge = dict(ctx.config["merge"])
+    assert merge.pop("output") == str(ctx.run_dir / "merged/merged.gpkg")
+    assert merge == {
+        "min_distance_m": 3.0,
+        "agreement": 1,
+        "min_adj_peak": 0.0,
+        "adjustment_factor": 1.0,
+        "thresholds_config": None,
+        "exclusion_zones_gpkg": None,
+        "inclusion_zone": None,
+    }
+
+
+def test_prepare_run_predict_artifacts_chain_the_stages_through_run_dir(tmp_path):
+    # Given: a flat predict base config pointing the stage folders at
+    #        locations outside the run directory
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "manifest_folder": "/elsewhere/manifests",
+                "prediction": {"input_folder": "/elsewhere/preds"},
+            }
+        )
+    )
+
+    # When: prepare_run builds a PREDICT run
+    ctx = prepare_run(PREDICT, base, run_name="p", run_root=tmp_path / "runs")
+
+    # Then: the scanner's manifest_folder and the predictor's input_folder
+    #       both resolve to <run_dir>/manifests (predict reads exactly what
+    #       scan wrote), predictions land in <run_dir>/preds, and the merge
+    #       output at <run_dir>/merged/merged.gpkg — the base values lose
+    run_dir = tmp_path / "runs" / "predict" / "p"
+    assert ctx.run_dir == run_dir
+    assert ctx.config["manifest_folder"] == str(run_dir / "manifests")
+    assert ctx.config["prediction"]["input_folder"] == str(run_dir / "manifests")
+    assert ctx.config["prediction"]["output_folder"] == str(run_dir / "preds")
+    assert ctx.config["merge"]["output"] == str(run_dir / "merged/merged.gpkg")
+
+
+def test_prepare_run_train_artifacts_chain_the_stages_through_run_dir(tmp_path):
+    # Given: a flat train base config pointing the manifest elsewhere
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"manifest": "/elsewhere/old.parquet"}))
+
+    # When: prepare_run builds a TRAIN run
+    ctx = prepare_run(TRAIN, base, run_name="t", run_root=tmp_path / "runs")
+
+    # Then: manifest_folder resolves to <run_dir>/manifests, the
+    #       rebalancer's output and the trainer's manifest both to
+    #       <run_dir>/dataset/balanced.parquet (train reads exactly what
+    #       rebalance wrote), and model artifacts to <run_dir>/model
+    run_dir = tmp_path / "runs" / "train" / "t"
+    assert ctx.run_dir == run_dir
+    assert ctx.config["manifest_folder"] == str(run_dir / "manifests")
+    assert ctx.config["rebalancing"]["out"] == str(run_dir / "dataset/balanced.parquet")
+    assert ctx.config["manifest"] == str(run_dir / "dataset/balanced.parquet")
+    assert ctx.config["artifact_dir"] == str(run_dir / "model")
+
+
+def test_stage_argv_runs_the_stage_module_on_the_resolved_config(tmp_path):
+    # Given: a prepared PREDICT run context and its scan stage
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"geotiff_dir": "/tifs"}))
+    ctx = prepare_run(PREDICT, base, run_name="r", run_root=tmp_path / "runs")
+    scan = PREDICT.stages[1]
+    assert scan.key == "scan"
+
+    # When: stage_argv builds the stage command line
+    argv = stage_argv(ctx, scan)
+
+    # Then: it is exactly [current interpreter, -m, the stage's module,
+    #       the resolved config written into the run dir] — every stage
+    #       executes against the run's own config.yaml, nothing else
+    assert argv == [
+        sys.executable,
+        "-m",
+        "displacement_tracker.b2_image_scanner",
+        str(ctx.run_dir / "config.yaml"),
+    ]
+
+
+def test_download_stage_is_opt_in_for_predict_and_train():
+    # Given: the shipped PREDICT and TRAIN specs
+    # When: a frontend selects the stages to run by their defaults
+    predict_stages = [(s.key, s.default_enabled) for s in PREDICT.stages]
+    train_stages = [(s.key, s.default_enabled) for s in TRAIN.stages]
+
+    # Then: "download" is the only stage disabled by default in both
+    #       pipelines — otherwise every default run would re-download
+    #       GeoTIFFs from Drive, clobbering curated local imagery — and
+    #       the remaining stages run in their documented order
+    assert predict_stages == [
+        ("download", False),
+        ("scan", True),
+        ("predict", True),
+        ("merge", True),
+    ]
+    assert train_stages == [
+        ("download", False),
+        ("scan", True),
+        ("rebalance", True),
+        ("train", True),
+    ]
+
+
+def test_default_run_root_prefers_data_dir(monkeypatch):
+    # Given: DATA_DIR set in the environment, and default_run_root's
+    #        load_dotenv() call stubbed out so a developer's .env cannot
+    #        contribute a value either way
+    monkeypatch.setattr(
+        "displacement_tracker.pipelines.runner.load_dotenv", lambda: None
+    )
+    monkeypatch.setenv("DATA_DIR", "/big/disk")
+
+    # When: default_run_root resolves the run root
+    root = default_run_root()
+
+    # Then: it is <DATA_DIR>/results/TentNetFA/pipeline_runs
+    assert root == os.path.join("/big/disk", "results", "TentNetFA", "pipeline_runs")
+
+
+def test_default_run_root_falls_back_to_local_repo(monkeypatch):
+    # Given: no DATA_DIR in the environment, with load_dotenv() stubbed so
+    #        a local .env cannot put it back (clearing the variable alone
+    #        would not survive the load_dotenv() inside default_run_root)
+    monkeypatch.setattr(
+        "displacement_tracker.pipelines.runner.load_dotenv", lambda: None
+    )
+    monkeypatch.delenv("DATA_DIR", raising=False)
+
+    # When: default_run_root resolves the run root
+    root = default_run_root()
+
+    # Then: it falls back to the repo-local runs/pipelines
+    assert root == os.path.join("runs", "pipelines")


### PR DESCRIPTION
Unit tests for how a run's configuration is assembled — the layer most likely to break silently, since a mis-resolved key produces a plausible-looking run rather than an error. 29 tests.

**Stack (merge bottom-up):** #35 infrastructure → #41 merge pipeline → #42 reference data → #43 tuning scan → **5/6 this PR** → #45 evaluation suite

## `util/config.py` (16 tests)

- **Dotted-path helpers** — `deep_get`/`deep_set`/`deep_merge`, including traversal through non-dict intermediates and the precedence order of a merge.
- **Sectioned resolution** — a `shared` section merged under the selected flow, with the flow's own values winning; sectioned-versus-flat detection; null sections tolerated; stray top-level keys rejected; deep copies returned so a caller mutating the result cannot corrupt the source.
- **Errors** — unknown flow names and a missing `--flow` both name the valid flows.
- Real YAML files in `tmp_path`, including environment-variable substitution.

## `pipelines/spec.py` + `pipelines/runner.py` (13 tests)

- **`prepare_run` layering** — the full precedence chain `defaults < base config < overrides < forced_values`, asserted end to end, including the tune pipeline's invariants (`min_adj_peak` 0, `adjustment_factor` 1, no `thresholds_config`) surviving a base config *and* overrides that deliberately poison them.
- **Artifact paths** — every stage's inputs and outputs forced under the run directory, so a run is self-contained; asserted for `PREDICT` and `TRAIN` as well as `TUNE`, since a typo in that wiring hands the predict stage an empty folder.
- **Shipped defaults** — `PREDICT`'s merge defaults resolved through `prepare_run` rather than restated from the source, so a value slip (`agreement` 1 → 2 silently drops every structure seen in only one image) fails a test.
- **Spec immutability** — `prepare_run` does not mutate the shared spec, checked by running twice.
- **`stage_argv`** — the documented `python -m <module> <resolved config>` contract; dropping the config path would leave every stage reading defaults.
- **The download stage is opt-in**, so runs do not silently re-download imagery and clobber curated files.

The `default_run_root` tests stub `load_dotenv` as well as clearing the environment variable — clearing alone is not enough, because `default_run_root()` calls `load_dotenv()` and a developer's `.env` puts the value straight back.

## Verification

Mutation testing on these modules caught 16 of 20 planted bugs outright; the four survivors were all unasserted shipped spec data (`PREDICT`/`TRAIN` defaults and artifact wiring, the `stage_argv` contract, the download stage default) and are covered here — behaviourally through `prepare_run` wherever possible, rather than by restating the spec dictionaries.

CI does not run on this PR while it targets a stack branch; it picks up automatically as the parents merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQjxWgZ242WWfxZhv6JPJ2