### PR TITLE
Tests for the evaluation suite (6/6)

### DIFF
--- a/tests/test_add_new_model_results.py
+++ b/tests/test_add_new_model_results.py
@@ -1,0 +1,278 @@
+"""Tests for displacement_tracker/evaluation/scripts/add_new_model_results.py."""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+import rasterio
+from shapely.geometry import Point
+
+from _helpers import CRS_UTM as UTM
+from _helpers import annotation_header, utm_to_lonlat, write_geotiff
+from displacement_tracker.evaluation.scripts.add_new_model_results import (
+    _unique_column_name,
+    add_new_model_results,
+)
+
+# Two tile centroids in UTM 36N, 1 km apart. Their 100 m tiles span
+# [x-50, x+50] x [y-50, y+50].
+C1 = (500000.0, 3474000.0)
+C2 = (501000.0, 3474000.0)
+
+
+def lonlat(xy):
+    return utm_to_lonlat(xy[0], xy[1])
+
+
+def write_annotation_csv(path, rows):
+    """rows: list of (date, utm_xy) — centroid stored as WGS84 lat/lon."""
+    lines = [annotation_header()]
+    for date, xy in rows:
+        lon, lat = lonlat(xy)
+        lines.append(f"{date},{lat},{lon},1\n")
+    path.write_text("".join(lines))
+    return str(path)
+
+
+def write_sample_tif(path, crs=UTM):
+    """A 1x1 placeholder raster; only its CRS and transform are read."""
+    return write_geotiff(
+        path,
+        np.zeros((1, 1), dtype=np.float32),
+        rasterio.transform.from_origin(500000.0, 3474000.0, 1.0, 1.0),
+        crs=crs,
+    )
+
+
+def write_predictions(path, utm_points, crs=UTM):
+    """Write prediction points given as UTM coordinates, in the given CRS."""
+    if crs == UTM:
+        geoms = [Point(x, y) for x, y in utm_points]
+    else:
+        geoms = [Point(*lonlat(p)) for p in utm_points]
+    gpd.GeoDataFrame(geometry=geoms, crs=crs).to_file(path, driver="GPKG")
+    return str(path)
+
+
+# ==========================================================
+# _unique_column_name
+# ==========================================================
+
+
+def test_unique_column_name_collision_fallback():
+    # Given: a frame that already has columns "m" and "m_1"
+    df = pd.DataFrame(columns=["m", "m_1"])
+
+    # When: a unique name is requested for the taken base "m"
+    taken = _unique_column_name(df, "m")
+
+    # Then: it falls back to the first free suffix, "m_2"
+    assert taken == "m_2"
+
+    # When: a unique name is requested for the absent base "x"
+    free = _unique_column_name(df, "x")
+
+    # Then: "x" is used as-is
+    assert free == "x"
+
+
+# ==========================================================
+# add_new_model_results
+# ==========================================================
+
+
+def test_counts_points_within_reconstructed_100m_tiles(tmp_path):
+    # Given: two annotated tiles (centroids C1 and C2, 100 m tiles = +/-50 m
+    #        boxes); the date's predictions hold 3 points strictly inside C1's
+    #        tile (offsets (10,10), (-49,0), (0,49)), one point 60 m east of C1
+    #        (outside both tiles), and none near C2
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-10-14", C2)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(
+        pred_dir / "20241014.gpkg",
+        [
+            (C1[0] + 10, C1[1] + 10),
+            (C1[0] - 49, C1[1]),
+            (C1[0], C1[1] + 49),
+            (C1[0] + 60, C1[1]),
+        ],
+    )
+
+    # When: add_new_model_results joins the predictions onto the annotations
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: C1's tile counts 3, C2's tile counts 0, and the manual column is
+    #       preserved unchanged in the written CSV
+    assert column == "new_model"
+    result = pd.read_csv(out_csv)
+    assert result["new_model"].tolist() == [3, 0]
+    assert result["manual_tent_count"].tolist() == [1, 1]
+
+
+def test_predictions_are_matched_per_date_file(tmp_path):
+    # Given: two annotation rows at the SAME centroid C1 but different dates;
+    #        20241014.gpkg holds 2 points inside the tile and 20241101.gpkg
+    #        holds 5
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-11-01", C1)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    inside = (C1[0] + 5, C1[1] - 5)
+    write_predictions(pred_dir / "20241014.gpkg", [inside] * 2)
+    write_predictions(pred_dir / "20241101.gpkg", [inside] * 5)
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: each row is counted only against its own date's file: [2, 5]
+    result = pd.read_csv(out_csv)
+    assert result.loc[result["date"] == "2024-10-14", column].tolist() == [2]
+    assert result.loc[result["date"] == "2024-11-01", column].tolist() == [5]
+
+
+def test_lonlat_predictions_reprojected_to_raster_crs(tmp_path):
+    # Given: prediction points stored in EPSG:4326 (converted from UTM offsets
+    #        (10,10) and (-30,20) inside C1's tile) while the sample tif is UTM
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(
+        pred_dir / "20241014.gpkg",
+        [(C1[0] + 10, C1[1] + 10), (C1[0] - 30, C1[1] + 20)],
+        crs="EPSG:4326",
+    )
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: predictions are reprojected before the spatial join, so both count
+    assert pd.read_csv(out_csv)[column].tolist() == [2]
+
+
+def test_missing_prediction_file_yields_na_only_for_that_date(tmp_path):
+    # Given: annotations on 2024-10-14 (predictions present, 1 point inside)
+    #        and 2024-11-01 (no gpkg on disk)
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-11-01", C1)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(pred_dir / "20241014.gpkg", [(C1[0], C1[1])])
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: the October row gets its count and the November row is NA,
+    #       not zero — absence of a file is not "zero tents"
+    result = pd.read_csv(out_csv)
+    assert result.loc[result["date"] == "2024-10-14", column].tolist() == [1]
+    assert result.loc[result["date"] == "2024-11-01", column].isna().all()
+
+
+def test_column_name_collision_appends_suffix_and_keeps_original(tmp_path):
+    # Given: the annotation CSV already carries a column named "new_model"
+    #        with value 42
+    ann_path = tmp_path / "ann.csv"
+    lon, lat = lonlat(C1)
+    ann_path.write_text(
+        "date,latitude,longitude,manual_tent_count,new_model\n"
+        f"2024-10-14,{lat},{lon},1,42\n"
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(pred_dir / "20241014.gpkg", [(C1[0], C1[1])])
+
+    # When: add_new_model_results is asked to add "new_model" again
+    out_csv, column = add_new_model_results(
+        annotation_csv=str(ann_path),
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: the counts land in "new_model_1" and the original column's value
+    #       survives untouched
+    assert column == "new_model_1"
+    result = pd.read_csv(out_csv)
+    assert result["new_model"].tolist() == [42]
+    assert result["new_model_1"].tolist() == [1]
+
+
+def test_missing_inputs_raise_file_not_found(tmp_path):
+    # Given: no annotation CSV at the path handed to the function
+    # When: add_new_model_results runs
+    # Then: the precondition fails fast with FileNotFoundError naming the
+    #       annotation input
+    with pytest.raises(FileNotFoundError, match="annotation"):
+        add_new_model_results(
+            annotation_csv=str(tmp_path / "nope.csv"),
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=str(tmp_path / "nope.tif"),
+            new_model_column="m",
+        )
+
+    # Given: an annotation CSV that now exists, but still no sample tif
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+
+    # When: add_new_model_results runs
+    # Then: the next precondition fails fast, naming the tif
+    with pytest.raises(FileNotFoundError, match="tif"):
+        add_new_model_results(
+            annotation_csv=ann,
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=str(tmp_path / "nope.tif"),
+            new_model_column="m",
+        )
+
+
+def test_sample_tif_without_crs_raises_value_error(tmp_path):
+    # Given: a sample tif written with no CRS
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+    tif = write_sample_tif(tmp_path / "nocrs.tif", crs=None)
+
+    # When: add_new_model_results tries to read the raster CRS
+    # Then: it raises ValueError instead of counting in an undefined CRS
+    with pytest.raises(ValueError, match="CRS"):
+        add_new_model_results(
+            annotation_csv=ann,
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=tif,
+            new_model_column="m",
+        )

--- a/tests/test_annotation_reference.py
+++ b/tests/test_annotation_reference.py
@@ -1,0 +1,251 @@
+"""Tests for displacement_tracker/evaluation/annotation_reference.py."""
+
+import numpy as np
+import pytest
+from rasterio.transform import from_origin
+from shapely.geometry import box
+
+from _helpers import CRS_UTM, CRS_WGS84, utm_to_lonlat, write_annotation_csv
+from displacement_tracker.evaluation.annotation_reference import (
+    ManualAnnotationReferenceSource,
+    _select_date,
+)
+
+# 0.01-degree grid anchored at (34.0 E, 32.0 N): cell (row r, col c) covers
+# lon [34.0 + 0.01c, 34.0 + 0.01(c+1)) and lat (32.0 - 0.01(r+1), 32.0 - 0.01r].
+GRID_TRANSFORM = from_origin(34.0, 32.0, 0.01, 0.01)
+GRID_SHAPE = (10, 10)
+
+
+# ==========================================================
+# Date selection
+# ==========================================================
+
+
+def test_multi_date_csv_without_date_raises_listing_available(tmp_path):
+    # Given: a CSV with annotations on 2024-10-14 and 2024-11-01
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.99,34.005,5\n", "2024-11-01,31.99,34.005,7\n"],
+    )
+
+    # When: the source is constructed without a date
+    # Then: it raises ValueError whose message lists both available dates
+    with pytest.raises(ValueError, match=r"2024-10-14.*2024-11-01"):
+        ManualAnnotationReferenceSource(csv)
+
+
+def test_single_date_csv_works_without_date(tmp_path):
+    # Given: a CSV whose rows all carry the same date, holding counts 5 and 4
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.965,34.025,4\n"],
+    )
+
+    # When: the source is constructed with date=None and rasterized
+    source = ManualAnnotationReferenceSource(csv)
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: no error is raised and both tiles are loaded (5 + 4 = 9)
+    assert counts.sum() == pytest.approx(9.0)
+
+
+def test_date_selection_accepts_dashed_and_compact_forms(tmp_path):
+    # Given: a two-date CSV (counts 5 on 2024-10-14, 7 on 2024-11-01)
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-11-01,31.995,34.005,7\n"],
+    )
+
+    # When: the source is built with date "2024-10-14" and with "20241014"
+    # Then: both forms select only the October rows (total count 5)
+    for date in ("2024-10-14", "20241014"):
+        source = ManualAnnotationReferenceSource(csv, date=date)
+        counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+        assert counts.sum() == pytest.approx(5.0)
+
+
+def test_unknown_date_raises_listing_available(tmp_path):
+    # Given: a CSV with only 2024-10-14 annotations
+    csv = write_annotation_csv(tmp_path / "ann.csv", ["2024-10-14,31.995,34.005,5\n"])
+
+    # When: the source is built for the absent date 2023-01-01
+    # Then: ValueError names the requested date and the available one
+    with pytest.raises(ValueError, match=r"2023-01-01.*2024-10-14"):
+        ManualAnnotationReferenceSource(csv, date="2023-01-01")
+
+
+def test_select_date_ignores_nan_dates_when_counting_ambiguity():
+    import pandas as pd
+
+    # Given: a frame with one real date plus a NaN date entry
+    df = pd.DataFrame({"date": ["2024-10-14", np.nan], "manual_tent_count": [1, 2]})
+
+    # When: _select_date runs with date=None
+    out = _select_date(df, None, "date", "fake.csv")
+
+    # Then: NaN does not count as a second date, so the frame passes through
+    #       with both rows intact
+    assert len(out) == 2
+
+
+def test_missing_csv_raises_file_not_found(tmp_path):
+    # Given: a path to a CSV that does not exist
+    missing = str(tmp_path / "nope.csv")
+
+    # When: the source is constructed on that path
+    # Then: FileNotFoundError is raised (not a pandas read error)
+    with pytest.raises(FileNotFoundError):
+        ManualAnnotationReferenceSource(missing)
+
+
+def test_missing_count_column_raises(tmp_path):
+    # Given: a CSV lacking the manual_tent_count column
+    csv = tmp_path / "ann.csv"
+    csv.write_text("date,latitude,longitude\n2024-10-14,31.99,34.005\n")
+
+    # When: the source is constructed
+    # Then: the column validation raises ValueError naming the column
+    with pytest.raises(ValueError, match="manual_tent_count"):
+        ManualAnnotationReferenceSource(str(csv))
+
+
+# ==========================================================
+# counts_on_grid
+# ==========================================================
+
+
+def test_counts_on_grid_additive_merge_and_cell_placement(tmp_path):
+    # Given: two tiles at (34.005, 31.995) with counts 5 and 7 — both in grid
+    #        cell (row 0, col 0) — and one tile at (34.025, 31.965) with count 4
+    #        in cell (row 3, col 2)
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        [
+            "2024-10-14,31.995,34.005,5\n",
+            "2024-10-14,31.995,34.005,7\n",
+            "2024-10-14,31.965,34.025,4\n",
+        ],
+    )
+    source = ManualAnnotationReferenceSource(csv)
+
+    # When: counts_on_grid rasterizes onto the 10x10 0.01-degree grid
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: cell (0,0) holds the SUM 12 (additive merge), cell (3,2) holds 4,
+    #       everything else is 0, and the dtype is float32
+    assert counts.dtype == np.float32
+    assert counts[0, 0] == pytest.approx(12.0)
+    assert counts[3, 2] == pytest.approx(4.0)
+    assert counts.sum() == pytest.approx(16.0)
+
+
+def test_counts_on_grid_reprojects_tiles_into_grid_crs(tmp_path):
+    # Given: a tile whose WGS84 centroid corresponds to UTM 36N (500000+50,
+    #        3474000+50) and a 100 m UTM grid anchored at (500000, 3474100)
+    lon, lat = utm_to_lonlat(500050.0, 3474050.0)
+    csv = write_annotation_csv(tmp_path / "ann.csv", [f"2024-10-14,{lat},{lon},9\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    utm_transform = from_origin(500000.0, 3474100.0, 100.0, 100.0)
+
+    # When: counts_on_grid runs with crs EPSG:32636
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM)
+
+    # Then: the tile's count 9 lands in cell (row 0, col 0) of the UTM grid
+    assert counts[0, 0] == pytest.approx(9.0)
+    assert counts.sum() == pytest.approx(9.0)
+
+
+def test_counts_on_grid_clip_geom_is_applied_in_grid_crs(tmp_path):
+    # Given: a tile whose WGS84 centroid reprojects to UTM 36N (500050,
+    #        3474050), the 3x3 100 m UTM grid anchored at (500000, 3474100),
+    #        and clip boxes expressed in the GRID CRS (as documented)
+    lon, lat = utm_to_lonlat(500050.0, 3474050.0)
+    csv = write_annotation_csv(tmp_path / "ann.csv", [f"2024-10-14,{lat},{lon},9\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    utm_transform = from_origin(500000.0, 3474100.0, 100.0, 100.0)
+
+    # When: counts_on_grid runs with crs EPSG:32636 and the clip box
+    #       box(500000, 3474000, 500100, 3474100), which contains the
+    #       REPROJECTED tile
+    containing = box(500000.0, 3474000.0, 500100.0, 3474100.0)
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM, containing)
+
+    # Then: the box keeps the tile — count 9 in cell (0, 0), since x 500050
+    #       falls in column 0's [500000, 500100) and y 3474050 in row 0's
+    #       (3474000, 3474100] — which requires reprojecting BEFORE clipping
+    #       (in WGS84 the tile sits near lon 34, nowhere near x=500000)
+    assert counts[0, 0] == pytest.approx(9.0)
+    assert counts.sum() == pytest.approx(9.0)
+
+    # When: the same call runs with box(500200, 3474000, 500300, 3474100),
+    #       which is disjoint from the reprojected tile
+    disjoint = box(500200.0, 3474000.0, 500300.0, 3474100.0)
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM, disjoint)
+
+    # Then: nothing survives the clip and the grid is all zeros
+    assert counts.sum() == 0.0
+
+
+def test_counts_on_grid_clip_geom_excludes_outside_tiles(tmp_path):
+    # Given: tiles at (34.005, 31.995) count 5 and (34.025, 31.965) count 4,
+    #        and a clip box covering only the first tile
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.965,34.025,4\n"],
+    )
+    source = ManualAnnotationReferenceSource(csv)
+    clip = box(34.0, 31.98, 34.02, 32.0)
+
+    # When: counts_on_grid runs with that clip_geom
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84, clip)
+
+    # Then: only the first tile contributes; total is 5 and cell (3,2) is 0
+    assert counts[0, 0] == pytest.approx(5.0)
+    assert counts[3, 2] == pytest.approx(0.0)
+    assert counts.sum() == pytest.approx(5.0)
+
+
+def test_counts_on_grid_all_clipped_returns_zeros(tmp_path):
+    # Given: one tile and a clip geometry that contains no tiles
+    csv = write_annotation_csv(tmp_path / "ann.csv", ["2024-10-14,31.995,34.005,5\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    clip = box(35.0, 30.0, 35.1, 30.1)
+
+    # When: counts_on_grid runs
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84, clip)
+
+    # Then: a float32 all-zero array of the grid shape is returned
+    assert counts.shape == GRID_SHAPE
+    assert counts.dtype == np.float32
+    assert counts.sum() == 0.0
+
+
+def test_nan_counts_are_dropped_not_rasterized(tmp_path):
+    # Given: two tiles in the same cell, one with count 5 and one with an
+    #        empty (NaN) count
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.995,34.005,\n"],
+    )
+
+    # When: the source loads and rasterizes them
+    source = ManualAnnotationReferenceSource(csv)
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: the NaN tile is dropped, leaving 5 in the cell (not NaN, not 5+0)
+    assert counts[0, 0] == pytest.approx(5.0)
+    assert np.isfinite(counts).all()
+
+
+def test_custom_count_column(tmp_path):
+    # Given: a CSV whose count column is named other_count (value 11)
+    csv = tmp_path / "ann.csv"
+    csv.write_text("date,latitude,longitude,other_count\n2024-10-14,31.995,34.005,11\n")
+
+    # When: the source is built with count_column="other_count" and rasterized
+    source = ManualAnnotationReferenceSource(str(csv), count_column="other_count")
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: that column drives the rasterized totals
+    assert counts[0, 0] == pytest.approx(11.0)

--- a/tests/test_evaluation_common.py
+++ b/tests/test_evaluation_common.py
@@ -1,0 +1,490 @@
+"""Tests for displacement_tracker/evaluation/scripts/common.py and the
+config-resolution/preflight logic of displacement_tracker/evaluation/run_all_analyses.py.
+"""
+
+import json
+import math
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")  # run_all_analyses imports plot modules
+
+import click
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+from shapely.geometry import Point, box
+
+from displacement_tracker.evaluation.run_all_analyses import cli, load_config, require
+from displacement_tracker.evaluation.scripts.common import (
+    build_hex_grid,
+    choose_utm_crs_from_gdf,
+    finite_xy,
+    group_error_summary,
+    hex_error_aggregation,
+    load_annotation_points,
+    load_annotations,
+    load_layer,
+    make_hexagon,
+    mean_error_ci,
+    read_annotations,
+)
+
+# ==========================================================
+# Annotation loading
+# ==========================================================
+
+
+def test_read_annotations_missing_columns_listed_sorted(tmp_path):
+    # Given: a CSV with only columns a and b
+    csv = tmp_path / "ann.csv"
+    csv.write_text("a,b\n1,2\n")
+
+    # When: read_annotations requires columns b, z, y and a (z and y absent)
+    # Then: it raises ValueError listing the missing columns in sorted order
+    #       ['y', 'z'], regardless of the order they were requested in
+    with pytest.raises(ValueError, match=r"\['y', 'z'\]"):
+        read_annotations(str(csv), required_columns=("b", "z", "y", "a"))
+
+
+def test_load_annotations_tile_error_is_model_minus_manual(tmp_path):
+    # Given: a CSV with manual counts [10, 4] and model counts [7, 9]
+    csv = tmp_path / "ann.csv"
+    csv.write_text("manual,model\n10,7\n4,9\n")
+
+    # When: load_annotations computes tile_error
+    df = load_annotations(str(csv), manual_column="manual", model_column="model")
+
+    # Then: tile_error is model - manual, i.e. [-3, 5]
+    assert df["tile_error"].tolist() == [-3, 5]
+
+
+def test_load_annotation_points_requires_lat_lon_and_builds_wgs84_points(tmp_path):
+    # Given: a CSV with lat/lon and count columns
+    csv = tmp_path / "ann.csv"
+    csv.write_text("latitude,longitude,manual,model\n31.5,34.25,3,8\n")
+
+    # When: load_annotation_points loads it
+    gdf = load_annotation_points(str(csv), manual_column="manual", model_column="model")
+
+    # Then: the result is EPSG:4326 points at (lon, lat) with tile_error attached
+    assert gdf.crs.to_epsg() == 4326
+    assert gdf.geometry.iloc[0].x == pytest.approx(34.25)
+    assert gdf.geometry.iloc[0].y == pytest.approx(31.5)
+    assert gdf["tile_error"].iloc[0] == 5
+
+
+def test_load_annotation_points_missing_latitude_raises(tmp_path):
+    # Given: a CSV that has longitude but no latitude column
+    csv = tmp_path / "ann.csv"
+    csv.write_text("longitude,manual,model\n34.25,3,8\n")
+
+    # When: load_annotation_points is called
+    # Then: the implicit latitude requirement fails with ValueError
+    with pytest.raises(ValueError, match="latitude"):
+        load_annotation_points(str(csv), manual_column="manual", model_column="model")
+
+
+def test_load_layer_reprojects_to_target_crs(tmp_path):
+    # Given: a GeoJSON point layer at lon 34.3 in EPSG:4326
+    path = tmp_path / "layer.geojson"
+    gpd.GeoDataFrame(
+        {"name": ["p"]}, geometry=[Point(34.3, 31.4)], crs="EPSG:4326"
+    ).to_file(path, driver="GeoJSON")
+
+    # When: load_layer is asked for EPSG:3857
+    out = load_layer(str(path), "EPSG:3857", required_columns=("name",))
+
+    # Then: the returned layer is in 3857 with x = R * radians(lon) (spherical
+    #       Mercator definition, R = 6378137 m)
+    assert out.crs.to_epsg() == 3857
+    assert out.geometry.iloc[0].x == pytest.approx(6378137 * math.radians(34.3))
+
+
+def test_load_layer_missing_required_column_raises(tmp_path):
+    # Given: a vector layer whose only attribute column is "name"
+    path = tmp_path / "layer.geojson"
+    gpd.GeoDataFrame({"name": ["p"]}, geometry=[Point(0, 0)], crs="EPSG:4326").to_file(
+        path, driver="GeoJSON"
+    )
+
+    # When: load_layer requires a column "kind" that is absent
+    # Then: it raises ValueError mentioning the missing column
+    with pytest.raises(ValueError, match="kind"):
+        load_layer(str(path), None, required_columns=("name", "kind"))
+
+
+def test_finite_xy_drops_pairs_with_any_nonfinite_member():
+    # Given: x = [1, nan, 3, inf, 5] and y = [10, 20, nan, 40, 50]
+    xs = [1, np.nan, 3, np.inf, 5]
+    ys = [10, 20, np.nan, 40, 50]
+
+    # When: finite_xy filters the pair
+    x, y = finite_xy(xs, ys)
+
+    # Then: only positions where BOTH are finite survive: (1,10) and (5,50)
+    assert x.tolist() == [1.0, 5.0]
+    assert y.tolist() == [10.0, 50.0]
+
+
+# ==========================================================
+# Error summaries
+# ==========================================================
+
+
+def test_mean_error_ci_hand_computed_four_values():
+    # Given: errors [1, 2, 3, 6] (mean 3; sample var = 14/3; std = sqrt(14/3))
+    errors = [1, 2, 3, 6]
+
+    # When: mean_error_ci runs with z = 1.96
+    stats = mean_error_ci(errors)
+
+    # Then: margin = 1.96 * sqrt(14/3) / 2 and the CI is mean -/+ margin
+    std = math.sqrt(14 / 3)
+    margin = 1.96 * std / 2
+    assert stats["mean_tile_error"] == pytest.approx(3.0)
+    assert stats["std_tile_error"] == pytest.approx(std, rel=1e-12)
+    assert stats["ci_lower"] == pytest.approx(3.0 - margin, rel=1e-12)
+    assert stats["ci_upper"] == pytest.approx(3.0 + margin, rel=1e-12)
+    assert stats["num_tiles"] == 4
+
+
+def test_mean_error_ci_single_value_has_zero_std_and_degenerate_ci():
+    # Given: a single error value 4.5
+    errors = [4.5]
+
+    # When: mean_error_ci runs
+    stats = mean_error_ci(errors)
+
+    # Then: std is 0.0 and both CI bounds equal the mean
+    assert stats == {
+        "mean_tile_error": 4.5,
+        "std_tile_error": 0.0,
+        "ci_lower": 4.5,
+        "ci_upper": 4.5,
+        "num_tiles": 1,
+    }
+
+
+def test_mean_error_ci_ignores_nonfinite_and_none_when_empty():
+    # Given: errors [1, nan, 3] (finite subset has mean 2, std sqrt(2), n=2)
+    errors = [1, np.nan, 3]
+
+    # When: mean_error_ci runs
+    stats = mean_error_ci(errors)
+
+    # Then: non-finite values are excluded so margin = 1.96 * sqrt(2)/sqrt(2) = 1.96
+    assert stats["num_tiles"] == 2
+    assert stats["mean_tile_error"] == pytest.approx(2.0)
+    assert stats["ci_lower"] == pytest.approx(2.0 - 1.96, rel=1e-12)
+    assert stats["ci_upper"] == pytest.approx(2.0 + 1.96, rel=1e-12)
+
+    # When: mean_error_ci runs on inputs with no finite value at all
+    # Then: there is nothing to summarize, so the result is None
+    assert mean_error_ci([np.nan, np.inf]) is None
+    assert mean_error_ci([]) is None
+
+
+def test_group_error_summary_per_group_stats_and_skips():
+    # Given: groups A -> errors [1, 3], B -> [5], C -> [nan], and one row with
+    #        a NaN group key
+    frame = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "C", np.nan],
+            "tile_error": [1.0, 3.0, 5.0, np.nan, 99.0],
+        }
+    )
+
+    # When: group_error_summary aggregates tile_error by group
+    out = group_error_summary(frame, "group")
+
+    # Then: A has mean 2, std sqrt(2), CI 2 -/+ 1.96, n=2; B has mean 5 with a
+    #       zero-width CI; C and the NaN-key row produce no rows at all
+    assert out["group"].tolist() == ["A", "B"]
+    a = out[out["group"] == "A"].iloc[0]
+    assert a["mean_tile_error"] == pytest.approx(2.0)
+    assert a["std_tile_error"] == pytest.approx(math.sqrt(2), rel=1e-12)
+    assert a["ci_lower"] == pytest.approx(2.0 - 1.96, rel=1e-12)
+    assert a["num_tiles"] == 2
+    b = out[out["group"] == "B"].iloc[0]
+    assert b["mean_tile_error"] == pytest.approx(5.0)
+    assert b["ci_lower"] == pytest.approx(5.0)
+    assert b["ci_upper"] == pytest.approx(5.0)
+
+
+# ==========================================================
+# Hex grid
+# ==========================================================
+
+
+def test_choose_utm_crs_northern_and_southern_hemispheres():
+    # Given: a point at lon 34.3 / lat 31.4 (zone int(214.3/6)+1 = 36, north)
+    #        and one at lon -58.4 / lat -34.6 (zone int(121.6/6)+1 = 21, south)
+    north = gpd.GeoDataFrame(geometry=[Point(34.3, 31.4)], crs="EPSG:4326")
+    south = gpd.GeoDataFrame(geometry=[Point(-58.4, -34.6)], crs="EPSG:4326")
+
+    # When: choose_utm_crs_from_gdf picks a UTM CRS for each
+    north_crs = choose_utm_crs_from_gdf(north)
+    south_crs = choose_utm_crs_from_gdf(south)
+
+    # Then: they resolve to EPSG:32636 and EPSG:32721 respectively
+    assert north_crs.to_epsg() == 32636
+    assert south_crs.to_epsg() == 32721
+
+
+def test_choose_utm_crs_requires_a_crs():
+    # Given: a layer with no CRS set
+    gdf = gpd.GeoDataFrame(geometry=[Point(0, 0)])
+
+    # When: choose_utm_crs_from_gdf runs
+    # Then: it refuses with ValueError instead of guessing
+    with pytest.raises(ValueError, match="no CRS"):
+        choose_utm_crs_from_gdf(gdf)
+
+
+def test_make_hexagon_geometry():
+    # Given: side length a=2 centered at (10, 5)
+    center_x, center_y, side = 10.0, 5.0, 2.0
+
+    # When: make_hexagon builds the polygon
+    hexagon = make_hexagon(center_x, center_y, side)
+
+    # Then: area is 3*sqrt(3)/2 * a^2 = 6*sqrt(3) and bounds span
+    #       [center_x - a, center_x + a] x [center_y - a*sqrt(3)/2, ...]
+    assert hexagon.area == pytest.approx(6 * math.sqrt(3), rel=1e-12)
+    minx, miny, maxx, maxy = hexagon.bounds
+    assert (minx, maxx) == pytest.approx((8.0, 12.0))
+    assert miny == pytest.approx(5 - math.sqrt(3), rel=1e-12)
+    assert maxy == pytest.approx(5 + math.sqrt(3), rel=1e-12)
+
+
+def test_build_hex_grid_tiles_the_bounds_without_gaps_or_overlaps():
+    # Given: bounds (0, 0, 20, 20), side length a=5, and four interior sample
+    #        points chosen to sit off any hex edge
+    bounds = (0.0, 0.0, 20.0, 20.0)
+    samples = [Point(1.1, 2.3), Point(9.7, 4.4), Point(15.2, 18.9), Point(19.3, 0.6)]
+
+    # When: build_hex_grid lays out the flat-topped grid
+    hexes = build_hex_grid(bounds, 5.0)
+
+    # Then: every sample point is covered by exactly one hexagon — no gaps, no
+    #       double coverage
+    for sample in samples:
+        covering = sum(1 for h in hexes if h.contains(sample))
+        assert covering == 1, f"{sample.wkt} covered by {covering} hexes"
+
+
+def test_hex_error_aggregation_groups_points_and_computes_stats(tmp_path):
+    # Given: a lon/lat boundary box around (34.30, 31.40) (UTM zone 36N), two
+    #        annotated tiles at the exact same location with errors 1 and 3,
+    #        and a third tile ~1.66 km north with error 7; hex_size_m=1000 so
+    #        the hex circumradius is 500 m (max in-hex distance 1000 m)
+    boundary_path = tmp_path / "boundary.geojson"
+    gpd.GeoDataFrame(
+        geometry=[box(34.28, 31.38, 34.32, 31.42)], crs="EPSG:4326"
+    ).to_file(boundary_path, driver="GeoJSON")
+
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0, 3.0, 7.0]},
+        geometry=[Point(34.30, 31.40), Point(34.30, 31.40), Point(34.30, 31.415)],
+        crs="EPSG:4326",
+    )
+
+    # When: hex_error_aggregation aggregates tile_error onto the hex grid
+    hex_gdf, points_with_hex, boundary_proj = hex_error_aggregation(
+        points, str(boundary_path), hex_size_m=1000.0
+    )
+
+    # Then: the co-located pair shares one hex (n=2, mean 2, std sqrt(2)), the
+    #       far tile sits alone in a DIFFERENT hex (n=1, mean 7, std NaN), and
+    #       hexes without points carry n_tiles=0 with NaN mean
+    assert boundary_proj.crs.to_epsg() == 32636
+    assert len(points_with_hex) == 3
+
+    pair_hex_ids = points_with_hex.loc[points_with_hex["tile_error"] < 5, "hex_id"]
+    lone_hex_id = points_with_hex.loc[points_with_hex["tile_error"] == 7.0, "hex_id"]
+    assert pair_hex_ids.nunique() == 1
+    pair_hex = pair_hex_ids.iloc[0]
+    lone_hex = lone_hex_id.iloc[0]
+    assert pair_hex != lone_hex  # 1.66 km apart > 1 km max in-hex distance
+
+    pair_row = hex_gdf.set_index("hex_id").loc[pair_hex]
+    assert pair_row["n_tiles"] == 2
+    assert pair_row["mean_err"] == pytest.approx(2.0)
+    assert pair_row["std_err"] == pytest.approx(math.sqrt(2), rel=1e-12)
+
+    lone_row = hex_gdf.set_index("hex_id").loc[lone_hex]
+    assert lone_row["n_tiles"] == 1
+    assert lone_row["mean_err"] == pytest.approx(7.0)
+    assert pd.isna(lone_row["std_err"])
+
+    empty = hex_gdf[~hex_gdf["hex_id"].isin([pair_hex, lone_hex])]
+    assert not empty.empty
+    assert (empty["n_tiles"] == 0).all()
+    assert empty["mean_err"].isna().all()
+
+
+def test_hex_error_aggregation_hex_geometry_matches_hex_size(tmp_path):
+    # Given: a small UTM-zone-36N boundary and hex_size_m=1000, which the
+    #        aggregation must convert to a hexagon side (circumradius) of
+    #        a = hex_size_m / 2 = 500 m — a side of 1000 m instead would
+    #        quadruple each hex's area and silently coarsen the spatial
+    #        resolution of the error maps
+    boundary_path = tmp_path / "boundary.geojson"
+    gpd.GeoDataFrame(
+        geometry=[box(34.28, 31.38, 34.32, 31.42)], crs="EPSG:4326"
+    ).to_file(boundary_path, driver="GeoJSON")
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0]}, geometry=[Point(34.30, 31.40)], crs="EPSG:4326"
+    )
+
+    # When: hex_error_aggregation builds its hex grid
+    hex_gdf, _, _ = hex_error_aggregation(points, str(boundary_path), hex_size_m=1000.0)
+
+    # Then: every returned hex has area 3*sqrt(3)/2 * 500^2, and its x-extent
+    #       is exactly 1000.0 m (make_hexagon places vertices at 0 and 180
+    #       degrees, so the corner-to-corner diameter 2a runs along x while
+    #       the y-extent is only sqrt(3)*a)
+    expected_area = 3 * math.sqrt(3) / 2 * 500.0**2
+    assert hex_gdf.geometry.area.to_numpy() == pytest.approx(expected_area, rel=1e-9)
+    minx, miny, maxx, maxy = hex_gdf.geometry.iloc[0].bounds
+    assert maxx - minx == pytest.approx(1000.0, abs=1e-6)
+    assert maxy - miny == pytest.approx(math.sqrt(3) * 500.0, abs=1e-6)
+
+
+def test_hex_error_aggregation_empty_boundary_raises(tmp_path):
+    # Given: a boundary layer file containing zero features
+    boundary_path = tmp_path / "empty.geojson"
+    gpd.GeoDataFrame(geometry=[], crs="EPSG:4326").to_file(
+        boundary_path, driver="GeoJSON"
+    )
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0]}, geometry=[Point(34.3, 31.4)], crs="EPSG:4326"
+    )
+
+    # When: hex_error_aggregation runs
+    # Then: it raises ValueError instead of building a grid over nothing
+    with pytest.raises(ValueError, match="empty"):
+        hex_error_aggregation(points, str(boundary_path), hex_size_m=1000.0)
+
+
+# ==========================================================
+# run_all_analyses config resolution and preflight
+# ==========================================================
+
+
+def test_load_config_resolves_relative_paths_against_config_dir(tmp_path):
+    # Given: a config file in tmp/cfgdir with a relative annotation_csv, an
+    #        absolute boundary_shp, a null prediction_dir and a non-path key
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    cfg_file = cfg_dir / "analysis.json"
+    absolute_boundary = str(tmp_path / "elsewhere" / "bounds.shp")
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "data/ann.csv",
+                "boundary_shp": absolute_boundary,
+                "prediction_dir": None,
+                "model_column": "model_tent_count",
+            }
+        )
+    )
+
+    # When: load_config loads it
+    cfg = load_config(cfg_file)
+
+    # Then: the relative path resolves against cfgdir (not the CWD), the
+    #       absolute path is preserved, null stays None and non-path keys
+    #       are untouched
+    assert cfg["annotation_csv"] == str((cfg_dir / "data" / "ann.csv").resolve())
+    assert cfg["boundary_shp"] == absolute_boundary
+    assert cfg["prediction_dir"] is None
+    assert cfg["model_column"] == "model_tent_count"
+
+
+def test_require_rejects_missing_and_falsy_values():
+    # Given: a config where key "a" is present, "b" is empty and "c" is absent
+    cfg = {"a": "value", "b": ""}
+
+    # When: require is called for the present key "a"
+    value = require(cfg, "a")
+
+    # Then: its value is returned
+    assert value == "value"
+
+    # When: require is called for the empty "b" and for the absent "c"
+    # Then: both raise ClickException naming the offending key
+    with pytest.raises(click.ClickException, match="b"):
+        require(cfg, "b")
+    with pytest.raises(click.ClickException, match="c"):
+        require(cfg, "c")
+
+
+def test_cli_preflight_lists_exactly_the_missing_inputs(tmp_path):
+    # Given: a config whose annotation_csv exists but whose four spatial
+    #        layers point at nonexistent relative paths
+    ann = tmp_path / "ann.csv"
+    ann.write_text("date,latitude,longitude,manual_tent_count,model_tent_count\n")
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "ann.csv",
+                "output_dir": "results",
+                "boundary_shp": "missing/bounds.shp",
+                "agriculture_geojson": "missing/agri.json",
+                "h3_geojson": "missing/h3.json",
+                "destruction_geojson": "missing/destr.json",
+            }
+        )
+    )
+
+    # When: the run-evaluation CLI runs its preflight check
+    result = CliRunner().invoke(cli, ["--config", str(cfg_file)])
+
+    # Then: it fails listing each missing resolved path, does not list the
+    #       existing annotation CSV, and does not create output_dir
+    assert result.exit_code != 0
+    for rel in ("bounds.shp", "agri.json", "h3.json", "destr.json"):
+        assert str((tmp_path / "missing" / rel).resolve()) in result.output
+    assert str(ann.resolve()) not in result.output
+    assert not (tmp_path / "results").exists()
+
+
+def test_cli_partial_new_model_config_fails_naming_missing_key(tmp_path):
+    # Given: a config whose preflight input files all exist as tiny dummies
+    #        and which sets prediction_dir but omits sample_tif and
+    #        new_model_column — a partially specified new-model run; this
+    #        exercises the fail-fast misconfiguration guard, not click
+    #        argument plumbing
+    ann = tmp_path / "ann.csv"
+    ann.write_text("date,latitude,longitude,manual_tent_count,model_tent_count\n")
+    for dummy in ("bounds.shp", "agri.json", "h3.json", "destr.json"):
+        (tmp_path / dummy).write_text("dummy")
+    (tmp_path / "preds").mkdir()
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "ann.csv",
+                "output_dir": "results",
+                "boundary_shp": "bounds.shp",
+                "agriculture_geojson": "agri.json",
+                "h3_geojson": "h3.json",
+                "destruction_geojson": "destr.json",
+                "prediction_dir": "preds",
+            }
+        )
+    )
+
+    # When: the run-evaluation CLI resolves the config
+    result = CliRunner().invoke(cli, ["--config", str(cfg_file)])
+
+    # Then: because ANY new-model key being set marks the run as a new-model
+    #       run, it aborts with "Missing required config key" naming
+    #       sample_tif instead of silently falling back to evaluating the
+    #       old model_column
+    assert result.exit_code != 0
+    assert "Missing required config key: sample_tif" in result.output


### PR DESCRIPTION
Unit tests for the analysis layer that scores model predictions against the manual tile annotations. 44 tests, completing the suite at 220.

**Stack (merge bottom-up):** #35 infrastructure → #41 merge pipeline → #42 reference data → #43 tuning scan → #44 config & pipelines → **6/6 this PR**

## `evaluation/scripts/common.py` (22 tests)

- **Error statistics** — per-tile error, and the mean-error confidence-interval summary asserted against values derived by hand (for errors `[1, 2, 3, 6]`: mean 3, std √(14/3), margin 1.96·std/2), plus the skip rules for non-finite and missing values and the `None` result when nothing finite remains.
- **Grouped summaries** — NaN groups and NaN values skipped rather than counted.
- **Hex aggregation** — UTM zone selection from longitude, hexagon geometry asserted directly (area `3√3/2·a²` and the corner-to-corner width, so a wrong `hex_size_m / 2` divisor cannot silently quadruple the cell area), gap- and overlap-free tiling, and the assignment of points to cells.
- **`require`** — missing and falsy config values rejected with a message naming the key.

## `evaluation/annotation_reference.py` (14 tests)

Date selection — required when the CSV spans several acquisition dates, with the error listing what is available; accepted in both dashed and compact form; NaN dates not counted as a second date. Rasterization of `manual_tent_count` onto the master grid with additive merging, hand-computed cell placement, reprojection into the grid CRS, and `clip_geom` applied *after* reprojection (the contract says the clip is expressed in the grid CRS, so clipping first would silently drop every tile and score predictions against zero ground truth).

## `evaluation/scripts/add_new_model_results.py` (8 tests)

Reconstruction of the 100 m tiles around stored centroids and the per-date spatial join that counts predictions inside them — including the distinction between a date with no predictions (NA) and a tile with none (0), and the fallback when the new model's column name collides with an existing one.

## `evaluation/run_all_analyses.py`

Config paths resolved relative to the config file rather than the working directory, the preflight listing exactly which inputs are missing, and the guard that a *partially* specified new-model config is a hard error — without it, setting `prediction_dir` but forgetting `new_model_column` silently evaluates the *old* model and publishes the numbers as if they were new.

## Verification

Mutation testing on these modules caught 13 of 17 planted bugs outright. The survivors are covered here: the dropped hex-size divisor, the `any`→`all` flip on the new-model guard, and the reproject-then-clip ordering. One near-equivalent mutant was deliberately not chased — `within` versus `intersects` for a point exactly on a shared hex edge — because no deterministic fixture distinguishes them while satisfying the invariant, and a flaky test would be worse than the gap.

## Known follow-up

**The `manual_eval` reference type is broken** and deliberately untouched by this stack. `annotation_reference.py` registers a bare class in `SOURCE_TYPES`, but `build_reference_source` unpacks `(factory, allowed_options)` tuples, so a config with `type: manual_eval` raises `TypeError` — while both error messages advertise it as valid. No test encodes either behavior. The fix is one line plus a `build_reference_source` test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQjxWgZ242WWfxZhv6JPJ2