### PR TITLE
Upgrade to ruff 0.16 and make the tree compatible with its expanded defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Same constraint as the dev dependency group in pyproject.toml
       - name: Install ruff
-        run: pip install "ruff>=0.15.0,<0.16.0"
+        run: pip install "ruff>=0.16.0,<0.17.0"
 
       - name: Lint
         run: ruff check .

--- a/displacement_tracker/a_tif_loader.py
+++ b/displacement_tracker/a_tif_loader.py
@@ -1,8 +1,9 @@
 import io
 import os
+
+import click
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseDownload
-import click
 
 from displacement_tracker.util.config import flow_option, load_flow_config
 from displacement_tracker.util.env_loader import require_env_file
@@ -88,11 +89,11 @@ def download_tif_files_from_public_folder(search_string: str, download_dir="."):
         done = False
         print(f"Downloading {file_name}...", end="\r")
         while not done:
-            status, done = downloader.next_chunk()
+            _status, done = downloader.next_chunk()
         print(f"Downloaded {file_name}")
 
 
-@click.command(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.command(context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument("config", type=click.Path(exists=True, dir_okay=False))
 @click.option(
     "--download-dir",

--- a/displacement_tracker/b2_image_scanner.py
+++ b/displacement_tracker/b2_image_scanner.py
@@ -11,10 +11,11 @@ import inspect
 import math
 import os
 import sys
+from collections.abc import Iterable, Iterator
 from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from concurrent.futures.process import BrokenProcessPool
 from itertools import islice
-from typing import Any, Iterable, Iterator
+from typing import Any
 
 import click
 import rasterio
@@ -304,9 +305,8 @@ def scan_all_coordinates(
                         completed += 1
                         pbar.update(1)
 
-                    if pool_broken:
-                        if not _restart_pool("future"):
-                            return
+                    if pool_broken and not _restart_pool("future"):
+                        return
         finally:
             try:
                 executor.shutdown(wait=False, cancel_futures=True)

--- a/displacement_tracker/d_train_cnn.py
+++ b/displacement_tracker/d_train_cnn.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
+
+import datetime
+import os
 from pathlib import Path
 
 import click
 import torch
+from torch import optim
 from torch.utils.data import DataLoader
-import torch.optim as optim
-import os
-import datetime
+
 from displacement_tracker.paired_image_dataset import PairedImageDataset
 from displacement_tracker.simple_cnn import SimpleCNN
 from displacement_tracker.util.config import flow_option, load_flow_config
@@ -44,7 +46,7 @@ def custom_collate(batch):
     collated_dict = {}
 
     # Iterate over keys in the first dictionary of the batch
-    for key in batch[0].keys():
+    for key in batch[0]:
         entry = [d[key] for d in batch]
 
         if key != "meta":
@@ -101,7 +103,7 @@ def train(
         device = torch.device("cpu")
         LOGGER.info("Using CPU")
     else:
-        raise Exception(f"Could not find device {device}")
+        raise ValueError(f"Could not find device {device}")
 
     if checkpoint:
         checkpoint = Path(checkpoint)
@@ -132,11 +134,11 @@ def train(
     else:
         loader_workers = int(num_workers)
 
-    loader_kwargs = dict(
-        batch_size=batch_size,
-        collate_fn=custom_collate,
-        num_workers=loader_workers,
-    )
+    loader_kwargs = {
+        "batch_size": batch_size,
+        "collate_fn": custom_collate,
+        "num_workers": loader_workers,
+    }
     if loader_workers > 0:
         loader_kwargs["worker_init_fn"] = PairedImageDataset.worker_init_fn
         loader_kwargs["persistent_workers"] = True
@@ -167,8 +169,9 @@ def train(
     # caching splits for future use
     with open(os.path.join(run_dir, "splits.csv"), "w") as split_file:
         split_file.write(",".join([str(split) for split in splits]) + "\n")
-        for idcs in idcs_list:
-            split_file.write(",".join([str(idx) for idx in idcs]) + "\n")
+        split_file.writelines(
+            ",".join([str(idx) for idx in idcs]) + "\n" for idcs in idcs_list
+        )
 
     best_eval = float("inf")
 

--- a/displacement_tracker/e_predict_json.py
+++ b/displacement_tracker/e_predict_json.py
@@ -1,24 +1,25 @@
-import click
-import torch
+import gc
 import json
+import os
+import tempfile
 from pathlib import Path
-from scipy.ndimage import label, center_of_mass, gaussian_filter
+
+import click
 import geopandas as gpd
+import psutil
+import torch
+from scipy.ndimage import center_of_mass, gaussian_filter, label
 from shapely.geometry import Point
 from torch.utils.data import DataLoader
-import gc
-import os
-import psutil
-import tempfile
 from tqdm.auto import tqdm
-# import matplotlib.pyplot as plt
 
+# import matplotlib.pyplot as plt
 from displacement_tracker.paired_image_dataset import PairedImageDataset
 from displacement_tracker.simple_cnn import SimpleCNN
 from displacement_tracker.util.config import flow_option, load_flow_config
-from displacement_tracker.util.logging_config import setup_logging
-from displacement_tracker.util.distance import interpolate_centroid
 from displacement_tracker.util.deduplication import merge_close_points_global
+from displacement_tracker.util.distance import interpolate_centroid
+from displacement_tracker.util.logging_config import setup_logging
 from displacement_tracker.util.thresholding import passes_threshold
 
 LOGGER = setup_logging("predict_json")
@@ -179,19 +180,19 @@ def predict(
             except Exception:
                 LOGGER.warning(f"Could not remove existing tmp file {tmp_ndjson}")
     else:
-        tmp_handle = tempfile.NamedTemporaryFile(
-            prefix="pred_points_", suffix=".ndjson", delete=False
-        )
-        tmp_handle.close()
-        tmp_ndjson = Path(tmp_handle.name)
+        # mkstemp rather than NamedTemporaryFile(delete=False): the file has
+        # to outlive this block, so there is no context manager to open.
+        tmp_fd, tmp_name = tempfile.mkstemp(prefix="pred_points_", suffix=".ndjson")
+        os.close(tmp_fd)
+        tmp_ndjson = Path(tmp_name)
 
-    loader_kwargs: dict = dict(
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=num_workers,
-        pin_memory=(device.type == "cuda"),
-        persistent_workers=False,
-    )
+    loader_kwargs: dict = {
+        "batch_size": batch_size,
+        "shuffle": True,
+        "num_workers": num_workers,
+        "pin_memory": (device.type == "cuda"),
+        "persistent_workers": False,
+    }
     if num_workers and num_workers > 0:
         loader_kwargs["worker_init_fn"] = PairedImageDataset.worker_init_fn
     loader = DataLoader(subset, **loader_kwargs)
@@ -313,7 +314,7 @@ def predict(
     except Exception:
         pass
 
-    print("")  # add new line after tqdm bars
+    print()  # add new line after tqdm bars
 
     LOGGER.info(f"Total number of tents (pre-merge): {len(flat_results)}")
 
@@ -471,7 +472,7 @@ def cli(config, flow) -> None:
             "Missing required config key: processing.margin_metres"
         )
     margin_metres = float(processing_cfg["margin_metres"])
-    margin_pixels = int(round(margin_metres / PIXEL_METRES))
+    margin_pixels = round(margin_metres / PIXEL_METRES)
     selection_cfg["crop_pixels"] = margin_pixels
     selection_cfg["nms_sigma"] = NMS_SIGMA_FRACTION * margin_pixels
     LOGGER.info(

--- a/displacement_tracker/evaluation/manual_eval/manual_eval.py
+++ b/displacement_tracker/evaluation/manual_eval/manual_eval.py
@@ -1,14 +1,15 @@
 import os
 import random
 import re
+import sys
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import geopandas as gpd
 import rasterio
 from rasterio.windows import from_bounds
 from shapely.geometry import box
-import matplotlib.pyplot as plt
-import sys
 
 # ==========================
 # CONFIGURATION
@@ -220,124 +221,126 @@ def main():
 
         region, date, time, satellite = parse_tif_name(tif_name)
 
-        with rasterio.open(tif_path) as src:
-            with rasterio.open(PREWAR_TIF) as prewar_src:
-                # ---- Load and align predictions ONCE ----
-                if os.path.exists(geojson_path):
-                    preds = gpd.read_file(geojson_path)
+        with (
+            rasterio.open(tif_path) as src,
+            rasterio.open(PREWAR_TIF) as prewar_src,
+        ):
+            # ---- Load and align predictions ONCE ----
+            if os.path.exists(geojson_path):
+                preds = gpd.read_file(geojson_path)
 
-                    if preds.empty:
-                        sys.exit("Prediction file is empty.")
-                    else:
-                        # If GeoJSON has no CRS, assume WGS84
-                        if preds.crs is None:
-                            preds.set_crs("EPSG:4326", inplace=True)
-
-                        # Reproject to raster CRS
-                        preds = preds.to_crs(src.crs)
-
-                        # Keep only predictions inside raster bounds
-                        raster_bounds_geom = box(*src.bounds)
-                        preds = preds[preds.intersects(raster_bounds_geom)]
+                if preds.empty:
+                    sys.exit("Prediction file is empty.")
                 else:
-                    preds = gpd.GeoDataFrame(geometry=[], crs=src.crs)
+                    # If GeoJSON has no CRS, assume WGS84
+                    if preds.crs is None:
+                        preds.set_crs("EPSG:4326", inplace=True)
 
-                # ---- sample until we have N_TILES_PER_IMAGE valid tiles ----
-                accepted = 0
-                attempts = 0
-                max_attempts = max(N_TILES_PER_IMAGE * 20, 500)
+                    # Reproject to raster CRS
+                    preds = preds.to_crs(src.crs)
 
-                while accepted < N_TILES_PER_IMAGE and attempts < max_attempts:
-                    attempts += 1
+                    # Keep only predictions inside raster bounds
+                    raster_bounds_geom = box(*src.bounds)
+                    preds = preds[preds.intersects(raster_bounds_geom)]
+            else:
+                preds = gpd.GeoDataFrame(geometry=[], crs=src.crs)
 
-                    tile_geom = random_tile_within_polygon(src, gaza_boundary)
+            # ---- sample until we have N_TILES_PER_IMAGE valid tiles ----
+            accepted = 0
+            attempts = 0
+            max_attempts = max(N_TILES_PER_IMAGE * 20, 500)
 
-                    window = from_bounds(*tile_geom.bounds, transform=src.transform)
+            while accepted < N_TILES_PER_IMAGE and attempts < max_attempts:
+                attempts += 1
 
-                    # prepare prewar window, reproject tile_geom to prewar CRS if necessary
-                    if prewar_src.crs == src.crs:
-                        prewar_geom = tile_geom
-                    else:
-                        prewar_geom = (
-                            gpd.GeoSeries([tile_geom], crs=src.crs)
-                            .to_crs(prewar_src.crs)
-                            .iloc[0]
-                        )
+                tile_geom = random_tile_within_polygon(src, gaza_boundary)
 
-                    prewar_window = from_bounds(
-                        *prewar_geom.bounds, transform=prewar_src.transform
+                window = from_bounds(*tile_geom.bounds, transform=src.transform)
+
+                # prepare prewar window, reproject tile_geom to prewar CRS if necessary
+                if prewar_src.crs == src.crs:
+                    prewar_geom = tile_geom
+                else:
+                    prewar_geom = (
+                        gpd.GeoSeries([tile_geom], crs=src.crs)
+                        .to_crs(prewar_src.crs)
+                        .iloc[0]
                     )
 
-                    # safe reads: skip tile if reading fails (out-of-range)
-                    try:
-                        tile_array = src.read(window=window)
-                        prewar_array = prewar_src.read(window=prewar_window)
-                    except Exception as e:
-                        print("Read error for sampled window, trying another tile:", e)
-                        continue
+                prewar_window = from_bounds(
+                    *prewar_geom.bounds, transform=prewar_src.transform
+                )
 
-                    # Ensure we have at least 3 bands
-                    if tile_array.shape[0] < 3:
-                        print("Tile has fewer than 3 bands, skipping")
-                        continue
+                # safe reads: skip tile if reading fails (out-of-range)
+                try:
+                    tile_array = src.read(window=window)
+                    prewar_array = prewar_src.read(window=prewar_window)
+                except Exception as e:
+                    print("Read error for sampled window, trying another tile:", e)
+                    continue
 
-                    # ---- Reject empty / nodata tiles ----
-                    nodata = src.nodata
-                    rgb = tile_array[:3]
+                # Ensure we have at least 3 bands
+                if tile_array.shape[0] < 3:
+                    print("Tile has fewer than 3 bands, skipping")
+                    continue
 
-                    # Condition 1: all zeros
-                    all_zero = np.all(rgb == 0)
+                # ---- Reject empty / nodata tiles ----
+                nodata = src.nodata
+                rgb = tile_array[:3]
 
-                    # Condition 2: all nodata (if defined)
-                    all_nodata = (nodata is not None) and np.all(rgb == nodata)
+                # Condition 1: all zeros
+                all_zero = np.all(rgb == 0)
 
-                    # Condition 3: extremely low variance (visually black)
-                    low_variance = np.std(rgb) < 1
+                # Condition 2: all nodata (if defined)
+                all_nodata = (nodata is not None) and np.all(rgb == nodata)
 
-                    # Condition 4: too few nonzero pixels (coverage)
-                    valid_pixels = np.sum(rgb > 0)
-                    total_pixels = rgb.size
-                    low_coverage = (valid_pixels / total_pixels) < 0.05
+                # Condition 3: extremely low variance (visually black)
+                low_variance = np.std(rgb) < 1
 
-                    if all_zero or all_nodata or low_variance or low_coverage:
-                        continue
+                # Condition 4: too few nonzero pixels (coverage)
+                valid_pixels = np.sum(rgb > 0)
+                total_pixels = rgb.size
+                low_coverage = (valid_pixels / total_pixels) < 0.05
 
-                    # accept this tile
-                    print(f"TILE {accepted + 1}/{N_TILES_PER_IMAGE}")
-                    manual_count = show_tile_and_get_count(tile_array, prewar_array)
-                    model_count = preds.within(tile_geom).sum()
+                if all_zero or all_nodata or low_variance or low_coverage:
+                    continue
 
-                    # Centroid in raster CRS
-                    centroid = tile_geom.centroid
+                # accept this tile
+                print(f"TILE {accepted + 1}/{N_TILES_PER_IMAGE}")
+                manual_count = show_tile_and_get_count(tile_array, prewar_array)
+                model_count = preds.within(tile_geom).sum()
 
-                    # Convert centroid to lat/lon
-                    centroid_gdf = gpd.GeoSeries([centroid], crs=src.crs).to_crs(
-                        "EPSG:4326"
-                    )
+                # Centroid in raster CRS
+                centroid = tile_geom.centroid
 
-                    lon = centroid_gdf.x.values[0]
-                    lat = centroid_gdf.y.values[0]
+                # Convert centroid to lat/lon
+                centroid_gdf = gpd.GeoSeries([centroid], crs=src.crs).to_crs(
+                    "EPSG:4326"
+                )
 
-                    rows.append(
-                        {
-                            "region": region,
-                            "date": date,
-                            "time": time,
-                            "satellite": satellite,
-                            "tif_name": tif_name,
-                            "latitude": lat,
-                            "longitude": lon,
-                            "manual_tent_count": manual_count,
-                            "model_tent_count": model_count,
-                        }
-                    )
+                lon = centroid_gdf.x.values[0]
+                lat = centroid_gdf.y.values[0]
 
-                    accepted += 1
+                rows.append(
+                    {
+                        "region": region,
+                        "date": date,
+                        "time": time,
+                        "satellite": satellite,
+                        "tif_name": tif_name,
+                        "latitude": lat,
+                        "longitude": lon,
+                        "manual_tent_count": manual_count,
+                        "model_tent_count": model_count,
+                    }
+                )
 
-                if accepted < N_TILES_PER_IMAGE:
-                    print(
-                        f"Warning: only collected {accepted}/{N_TILES_PER_IMAGE} tiles for {tif_name} after {attempts} attempts."
-                    )
+                accepted += 1
+
+            if accepted < N_TILES_PER_IMAGE:
+                print(
+                    f"Warning: only collected {accepted}/{N_TILES_PER_IMAGE} tiles for {tif_name} after {attempts} attempts."
+                )
 
     df = pd.DataFrame(rows)
 

--- a/displacement_tracker/evaluation/scripts/evaluate_month.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_month.py
@@ -4,12 +4,12 @@ import os
 
 import pandas as pd
 
-from displacement_tracker.evaluation.scripts.plots import plot_error_bars
 from displacement_tracker.evaluation.scripts.common import (
     ensure_output_dir,
     group_error_summary,
     load_annotations,
 )
+from displacement_tracker.evaluation.scripts.plots import plot_error_bars
 
 
 def evaluate_error_by_month(

--- a/displacement_tracker/evaluation/scripts/evaluate_municipal_bounds.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_municipal_bounds.py
@@ -134,7 +134,7 @@ def _plot_municipal_scatter(
     n_cols = 3
     n_rows = int(np.ceil(len(unique_regions) / n_cols))
 
-    fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 5 * n_rows))
+    _fig, axes = plt.subplots(n_rows, n_cols, figsize=(5 * n_cols, 5 * n_rows))
     axes = np.array(axes).reshape(-1)
 
     for ax, region in zip(axes, unique_regions):

--- a/displacement_tracker/evaluation/scripts/evaluate_spatial_points.py
+++ b/displacement_tracker/evaluation/scripts/evaluate_spatial_points.py
@@ -44,7 +44,7 @@ def evaluate_spatial_points(
 
     return {
         "output_path": output_path,
-        "n_points": int(len(df)),
+        "n_points": len(df),
         "n_hexes": n_hexes,
         "mean_tile_error": float(df["tile_error"].mean()),
     }

--- a/displacement_tracker/evaluation/scripts/plots.py
+++ b/displacement_tracker/evaluation/scripts/plots.py
@@ -125,7 +125,7 @@ def plot_error_hexbin(lon, lat, errors, gridsize: int, output_path: str) -> int:
     plt.savefig(output_path)
     plt.close()
 
-    return int(len(hex_means))
+    return len(hex_means)
 
 
 def plot_hex_error_map(

--- a/displacement_tracker/evaluation/scripts/spatial_bootstrap_hex.py
+++ b/displacement_tracker/evaluation/scripts/spatial_bootstrap_hex.py
@@ -5,12 +5,12 @@ import os
 import numpy as np
 import pandas as pd
 
-from displacement_tracker.evaluation.scripts.plots import plot_hex_error_map
 from displacement_tracker.evaluation.scripts.common import (
     ensure_output_dir,
     hex_error_aggregation,
     load_annotation_points,
 )
+from displacement_tracker.evaluation.scripts.plots import plot_hex_error_map
 
 
 def spatial_bootstrap_hex(

--- a/displacement_tracker/evaluation/scripts/total_error.py
+++ b/displacement_tracker/evaluation/scripts/total_error.py
@@ -5,13 +5,13 @@ import os
 import numpy as np
 import pandas as pd
 
-from displacement_tracker.evaluation.scripts.plots import plot_hex_error_map
 from displacement_tracker.evaluation.scripts.common import (
     Z_95,
     ensure_output_dir,
     hex_error_aggregation,
     load_annotation_points,
 )
+from displacement_tracker.evaluation.scripts.plots import plot_hex_error_map
 
 TILE_SIZE_M = 100.0
 TILE_AREA_M2 = TILE_SIZE_M * TILE_SIZE_M

--- a/displacement_tracker/f_evaluate_geojson.py
+++ b/displacement_tracker/f_evaluate_geojson.py
@@ -1,9 +1,8 @@
 import json
+import math
 from dataclasses import dataclass
-from typing import Dict, List, Tuple, Optional
 
 import click
-import math
 
 
 @dataclass(frozen=True)
@@ -27,25 +26,25 @@ def lonlat_dist(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
     return math.hypot(lon2 - lon1, lat2 - lat1)
 
 
-def load_geojson(path: str) -> Dict:
+def load_geojson(path: str) -> dict:
     with open(path, "r") as f:
         return json.load(f)
 
 
-def is_point_feature(feat: Dict) -> bool:
+def is_point_feature(feat: dict) -> bool:
     return feat.get("geometry", {}).get("type") == "Point"
 
 
-def is_polygon_feature(feat: Dict) -> bool:
+def is_polygon_feature(feat: dict) -> bool:
     return feat.get("geometry", {}).get("type") in {"Polygon", "MultiPolygon"}
 
 
-def feature_coords(feat: Dict) -> List:
+def feature_coords(feat: dict) -> list:
     return feat.get("geometry", {}).get("coordinates", [])
 
 
 def extract_bounds_from_polygon_feature(
-    feat: Dict, default_width: int = 0, default_height: int = 0
+    feat: dict, default_width: int = 0, default_height: int = 0
 ) -> Bounds:
     geom = feat.get("geometry", {})
     coords = geom.get("coordinates")
@@ -87,8 +86,8 @@ def extract_bounds_from_polygon_feature(
     )
 
 
-def collect_points(fc: Dict) -> List[Tuple[float, float, Dict]]:
-    pts: List[Tuple[float, float, Dict]] = []
+def collect_points(fc: dict) -> list[tuple[float, float, dict]]:
+    pts: list[tuple[float, float, dict]] = []
     for feat in fc.get("features", []):
         if is_point_feature(feat):
             lon, lat = feature_coords(feat)
@@ -96,8 +95,8 @@ def collect_points(fc: Dict) -> List[Tuple[float, float, Dict]]:
     return pts
 
 
-def collect_bounds(fc: Dict) -> List[Bounds]:
-    bounds_list: List[Bounds] = []
+def collect_bounds(fc: dict) -> list[Bounds]:
+    bounds_list: list[Bounds] = []
     for feat in fc.get("features", []):
         if is_polygon_feature(feat):
             try:
@@ -110,9 +109,9 @@ def collect_bounds(fc: Dict) -> List[Bounds]:
 
 
 def group_points_by_bounds(
-    points: List[Tuple[float, float, Dict]], bounds_list: List[Bounds]
-) -> Dict[int, List[Tuple[float, float, Dict]]]:
-    groups: Dict[int, List[Tuple[float, float, Dict]]] = {
+    points: list[tuple[float, float, dict]], bounds_list: list[Bounds]
+) -> dict[int, list[tuple[float, float, dict]]]:
+    groups: dict[int, list[tuple[float, float, dict]]] = {
         i: [] for i in range(len(bounds_list))
     }
     for lon, lat, props in points:
@@ -134,7 +133,7 @@ class TileStats:
         self.fp += other.fp
         self.fn += other.fn
 
-    def to_dict(self) -> Dict:
+    def to_dict(self) -> dict:
         total_pred = self.tp + self.fp
         total_gt = self.tp + self.fn
         denom = self.tp + self.fp + self.fn
@@ -162,8 +161,8 @@ class TileStats:
 
 
 def match_points_per_tile_lonlat(
-    gt_pts: List[Tuple[float, float, Dict]],
-    pred_pts: List[Tuple[float, float, Dict]],
+    gt_pts: list[tuple[float, float, dict]],
+    pred_pts: list[tuple[float, float, dict]],
     dist_deg: float,
 ) -> TileStats:
     # Prepare coordinate lists
@@ -171,8 +170,8 @@ def match_points_per_tile_lonlat(
     pr_coords = [(lon, lat) for lon, lat, _ in pred_pts]
 
     # Build list of (distance, gt_idx, pred_idx) for pairs within threshold (degrees)
-    pairs: List[Tuple[float, int, int]] = []
-    near_gt_for_pred: List[List[int]] = [[] for _ in range(len(pr_coords))]
+    pairs: list[tuple[float, int, int]] = []
+    near_gt_for_pred: list[list[int]] = [[] for _ in range(len(pr_coords))]
 
     for gi, (glon, glat) in enumerate(gt_coords):
         for pi, (plon, plat) in enumerate(pr_coords):
@@ -237,7 +236,7 @@ def cli(
     pred_geojson: str,
     dist_deg: float,
     per_tile: bool,
-    save_report: Optional[str],
+    save_report: str | None,
     global_match: bool,
 ):
     """
@@ -282,7 +281,7 @@ def cli(
         pr_by_tile = group_points_by_bounds(pred_points, bounds_list)
 
         overall = TileStats()
-        per_tile_stats: List[Dict] = []
+        per_tile_stats: list[dict] = []
 
         for i, bounds in enumerate(bounds_list):
             gt_tile = gt_by_tile.get(i, [])

--- a/displacement_tracker/g1_scan_validation.py
+++ b/displacement_tracker/g1_scan_validation.py
@@ -28,9 +28,9 @@ validation at a single fixed (factor, cutoff), see g2_validate_geojson.py.
 """
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple
 
 import click
 import geopandas as gpd
@@ -89,7 +89,7 @@ def make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
     rows_arr = pred_prepped["row"].to_numpy(dtype=np.int32)
     cols_arr = pred_prepped["col"].to_numpy(dtype=np.int32)
 
-    def evaluate(factor: float, cutoff: float) -> Optional[Dict[str, float]]:
+    def evaluate(factor: float, cutoff: float) -> dict[str, float] | None:
         keep = keep_mask_from_params(
             pred_prepped, factor=float(factor), cutoff=float(cutoff)
         )
@@ -146,14 +146,14 @@ def objective(evaluate: Callable, metric: str, factor: float, cutoff: float) -> 
 def optimize_metric(
     evaluate: Callable,
     metric: str,
-    bests: Dict[str, dict],
-    factor_bounds: Tuple[float, float],
-    cutoff_bounds: Tuple[float, float],
+    bests: dict[str, dict],
+    factor_bounds: tuple[float, float],
+    cutoff_bounds: tuple[float, float],
     n_probes: int,
     xtol_factor: float,
     xtol_cutoff: float,
     refine_maxiter: int,
-) -> Tuple[float, float]:
+) -> tuple[float, float]:
     """Ridge-aware search for one metric. Returns the fitted ridge (a, b).
 
     The "best" is tracked via side effects in `bests` — callers can read
@@ -164,7 +164,7 @@ def optimize_metric(
 
     # --- Phase 1: probe the ridge at n_probes factors ---
     probe_factors = np.linspace(fb_lo, fb_hi, n_probes)
-    ridge_pts: List[Tuple[float, float]] = []
+    ridge_pts: list[tuple[float, float]] = []
     for f in probe_factors:
         res = minimize_scalar(
             lambda c, _f=float(f): objective(evaluate, metric, _f, c),
@@ -220,8 +220,8 @@ def optimize_metric(
 
 def scan_tile(
     grouped,
-    factor_bounds: Tuple[float, float],
-    cutoff_bounds: Tuple[float, float],
+    factor_bounds: tuple[float, float],
+    cutoff_bounds: tuple[float, float],
     scan_metrics,
     n_probes: int,
     xtol_factor: float,
@@ -245,10 +245,10 @@ def scan_tile(
         }
         for m in scan_metrics
     }
-    trace: List[Dict[str, float]] = []
+    trace: list[dict[str, float]] = []
 
     evaluate = make_evaluator(grouped, scan_metrics, bests, trace, progress=progress)
-    ridges: Dict[str, Tuple[float, float]] = {}
+    ridges: dict[str, tuple[float, float]] = {}
     for m in scan_metrics:
         a, b = optimize_metric(
             evaluate=evaluate,
@@ -291,7 +291,7 @@ def plot_search_trace(
         values = np.array([t[metric] for t in trace], dtype=float)
         finite = np.isfinite(values)
         cmap = "viridis" if METRIC_DIRECTIONS[metric] == "max" else "viridis_r"
-        kwargs = dict(cmap=cmap, s=14)
+        kwargs = {"cmap": cmap, "s": 14}
         if metric == "spearman":
             kwargs.update(vmin=-1, vmax=1)
         sc = ax.scatter(factors[finite], cutoffs[finite], c=values[finite], **kwargs)
@@ -327,7 +327,7 @@ def plot_search_trace(
     plt.close(fig)
 
 
-def resolve_metrics(tuning_cfg: dict) -> Tuple[str, List[str]]:
+def resolve_metrics(tuning_cfg: dict) -> tuple[str, list[str]]:
     """Return (eval metric, metrics to track); the eval metric is always tracked."""
     metric = tuning_cfg.get("metric", "rms")
     metrics = list(tuning_cfg.get("metrics") or SCAN_METRICS_DEFAULT)
@@ -353,20 +353,20 @@ class ScanSettings:
     """Validated inputs of one threshold scan, extracted from the config."""
 
     input_path: str
-    pred_folder: Optional[str]  # pre-merge prediction files (date-stamped)
+    pred_folder: str | None  # pre-merge prediction files (date-stamped)
     master_grid: str
     reference: object  # config for build_reference_source
     out_dir: str
     best_params_path: str
     metric: str
-    scan_metrics: List[str]
-    factor_bounds: Tuple[float, float]
-    cutoff_bounds: Tuple[float, float]
+    scan_metrics: list[str]
+    factor_bounds: tuple[float, float]
+    cutoff_bounds: tuple[float, float]
     ridge_probes: int
     xtol_factor: float
     xtol_cutoff: float
     refine_maxiter: int
-    exclusion_zones: Optional[str]
+    exclusion_zones: str | None
 
     @property
     def base_name(self) -> str:
@@ -444,7 +444,7 @@ def _load_predictions(settings: ScanSettings, raster_crs) -> gpd.GeoDataFrame:
     return pred_gdf
 
 
-def _export_best(settings: ScanSettings, grouped, chosen, src_grid) -> Dict[str, float]:
+def _export_best(settings: ScanSettings, grouped, chosen, src_grid) -> dict[str, float]:
     """Write the rasters at the chosen optimum; return its final metrics."""
     pred_prepped = grouped["pred_prepped"]
     processed = process_grouped_cells(

--- a/displacement_tracker/h_merge_geojsons.py
+++ b/displacement_tracker/h_merge_geojsons.py
@@ -21,8 +21,8 @@ from pathlib import Path
 
 import click
 import geopandas as gpd
-from shapely.geometry import Point
 import yaml
+from shapely.geometry import Point
 
 from displacement_tracker.util.config import flow_option, load_flow_config
 from displacement_tracker.util.deduplication import merge_close_points_global
@@ -397,15 +397,15 @@ def merge_geojsons(
     exclusion_geom = load_zone_geometry(exclusion_zones_gpkg, "exclusion")
     inclusion_geom = load_zone_geometry(inclusion_zone, "inclusion")
 
-    merge_kwargs = dict(
-        min_distance_m=min_distance_m,
-        agreement=agreement,
-        min_adj_peak=min_adj_peak,
-        adjustment_factor=adjustment_factor,
-        thresholds_data=thresholds_data,
-        exclusion_geom=exclusion_geom,
-        inclusion_geom=inclusion_geom,
-    )
+    merge_kwargs = {
+        "min_distance_m": min_distance_m,
+        "agreement": agreement,
+        "min_adj_peak": min_adj_peak,
+        "adjustment_factor": adjustment_factor,
+        "thresholds_data": thresholds_data,
+        "exclusion_geom": exclusion_geom,
+        "inclusion_geom": inclusion_geom,
+    }
 
     if process_by_date:
         sort_preds_by_date(input_dir)

--- a/displacement_tracker/paired_image_dataset.py
+++ b/displacement_tracker/paired_image_dataset.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 import os
 import random
@@ -206,7 +207,7 @@ class PairedImageDataset(Dataset):
         save_loc: str | None = None,
         regenerate_splits: bool = False,
         seed: int | None = None,
-    ) -> tuple[list["PairedImageDataset"], list[list[int]]]:
+    ) -> tuple[list[PairedImageDataset], list[list[int]]]:
         if save_loc is None:
             cache_valid = False
         else:
@@ -226,7 +227,7 @@ class PairedImageDataset(Dataset):
                         [int(field.strip()) for field in row.strip().split(",")]
                     )
             else:
-                LOGGER.warn("Cached splits don't match args, ignoring cache")
+                LOGGER.warning("Cached splits don't match args, ignoring cache")
                 cache_valid = False
 
         idcs = list(range(len(self)))

--- a/displacement_tracker/pipelines/app.py
+++ b/displacement_tracker/pipelines/app.py
@@ -472,9 +472,8 @@ def main() -> None:
         with open(ctx.config_path, "w") as f:
             yaml.safe_dump(ctx.config, f, sort_keys=False)
 
-    with config_tab:
-        with st.expander("Resolved config (as written to the run directory)"):
-            st.code(yaml.safe_dump(ctx.config, sort_keys=False), language="yaml")
+    with config_tab, st.expander("Resolved config (as written to the run directory)"):
+        st.code(yaml.safe_dump(ctx.config, sort_keys=False), language="yaml")
 
     with logs_tab:
         st.info(f"Run directory: `{ctx.run_dir}`")

--- a/displacement_tracker/pipelines/runner.py
+++ b/displacement_tracker/pipelines/runner.py
@@ -24,15 +24,15 @@ import os
 import signal
 import subprocess
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
 
 import yaml
 from dotenv import load_dotenv
 
-from displacement_tracker.util.config import deep_merge, deep_set, load_flow_config
 from displacement_tracker.pipelines.spec import Pipeline, Stage
+from displacement_tracker.util.config import deep_merge, deep_set, load_flow_config
 
 
 class StageFailedError(RuntimeError):
@@ -81,7 +81,7 @@ class StageLoadMonitor:
 
         self._psutil = psutil
         self._root_pid = proc.pid
-        self._procs: dict[int, "psutil.Process"] = {}
+        self._procs: dict[int, psutil.Process] = {}
         self.cpu_count: int = psutil.cpu_count() or 1
         self.total_memory: int = psutil.virtual_memory().total
         self.sample()  # prime the cpu_percent counters

--- a/displacement_tracker/pipelines/stop.py
+++ b/displacement_tracker/pipelines/stop.py
@@ -100,7 +100,7 @@ def cli(dry_run: bool, timeout: float) -> None:
             proc.terminate()
         except psutil.NoSuchProcess:
             continue
-    gone, alive = psutil.wait_procs(procs, timeout=timeout)
+    _gone, alive = psutil.wait_procs(procs, timeout=timeout)
     for proc in alive:
         LOGGER.warning("pid %d did not exit within %.0fs — killing", proc.pid, timeout)
         try:

--- a/displacement_tracker/simple_cnn.py
+++ b/displacement_tracker/simple_cnn.py
@@ -1,9 +1,11 @@
+from typing import ClassVar
+
 import torch
-import torch.nn as nn
+from torch import nn
 
 
 class SimpleCNN(nn.Module):
-    ALLOWED_KWARGS = {"kernel_size", "dropout"}
+    ALLOWED_KWARGS: ClassVar[set[str]] = {"kernel_size", "dropout"}
 
     def __init__(self, n_channels, n_classes=1, **kwargs):
         super().__init__()
@@ -114,7 +116,7 @@ class SimpleCNN(nn.Module):
         g = self.global_pool(x)  # (B, 8, 1, 1)
         g = self.global_fc(g)  # (B, 8, 1, 1)
         g = self.global_relu(g)
-        x = x  # + g  # broadcast add  # COMMENTED OUT DELIBERATELY TO REMOVE BUG BUT KEEP COMPATIBILITY WITH TRAINED MODEL
+        x = x  # noqa: PLW0127  # + g  # broadcast add  # COMMENTED OUT DELIBERATELY TO REMOVE BUG BUT KEEP COMPATIBILITY WITH TRAINED MODEL
 
         x = self.convend(x)
         return x

--- a/displacement_tracker/util/env_loader.py
+++ b/displacement_tracker/util/env_loader.py
@@ -1,8 +1,9 @@
 import os
-from functools import wraps
-from dotenv import load_dotenv
-import yaml
 import re
+from functools import wraps
+
+import yaml
+from dotenv import load_dotenv
 
 
 class EnvFileNotFoundError(FileNotFoundError):

--- a/displacement_tracker/util/manifest_writer.py
+++ b/displacement_tracker/util/manifest_writer.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
@@ -49,7 +50,7 @@ MANIFEST_STATS_KEY = "raster_stats"
 def compute_tile_id(raster_path: str, r0: int, c0: int) -> int:
     """Deterministic uint64 hash so split caches stay stable across re-runs."""
     digest = hashlib.blake2b(
-        f"{raster_path}|{r0}|{c0}".encode("utf-8"), digest_size=8
+        f"{raster_path}|{r0}|{c0}".encode(), digest_size=8
     ).digest()
     return int.from_bytes(digest, byteorder="little", signed=False)
 
@@ -121,7 +122,9 @@ class ManifestWriter:
         os.replace(tmp, self.path)
         return table
 
-    def __enter__(self) -> "ManifestWriter":
+    # PYI034 wants `Self` here, which typing only gained in 3.11; the project
+    # floor is 3.10, so the class name stays.
+    def __enter__(self) -> ManifestWriter:  # noqa: PYI034
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/displacement_tracker/util/reference_data.py
+++ b/displacement_tracker/util/reference_data.py
@@ -35,9 +35,9 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable, List, Optional, Tuple, Union
 
 import geopandas as gpd
 import numpy as np
@@ -56,7 +56,7 @@ RASTER_SUFFIXES = (".tif", ".tiff", ".vrt")
 _DATE_PATTERN = re.compile(r"(\d{4}-\d{2}-\d{2})|(\d{8})")
 
 
-def extract_date_from_filename(path) -> Optional[datetime]:
+def extract_date_from_filename(path) -> datetime | None:
     """Match YYYY-MM-DD or YYYYMMDD in a file name (None if absent/invalid)."""
     match = _DATE_PATTERN.search(Path(path).name)
     if not match:
@@ -67,7 +67,7 @@ def extract_date_from_filename(path) -> Optional[datetime]:
         return None
 
 
-def infer_target_date(paths: Iterable[Union[str, Path]]) -> Optional[datetime]:
+def infer_target_date(paths: Iterable[str | Path]) -> datetime | None:
     """Median of the dates stamped on the given file names (None if none parse).
 
     Used to auto-discover a reference export near the prediction dates; the
@@ -87,7 +87,7 @@ class ReferenceSource(ABC):
     @abstractmethod
     def counts_on_grid(
         self,
-        grid_shape: Tuple[int, int],
+        grid_shape: tuple[int, int],
         transform: rasterio.Affine,
         crs,
         clip_geom=None,
@@ -127,8 +127,8 @@ class VectorReferenceSource(PointsSource):
     def __init__(
         self,
         path: str,
-        layer: Optional[str] = None,
-        where: Optional[str] = None,
+        layer: str | None = None,
+        where: str | None = None,
     ):
         source_path = Path(path)
         if not source_path.exists():
@@ -166,17 +166,17 @@ class UnosatReferenceSource(VectorReferenceSource):
     def __init__(
         self,
         path: str,
-        date: Optional[str] = None,
-        nearest_to: Optional[datetime] = None,
-        layer: Optional[str] = None,
-        where: Optional[str] = None,
+        date: str | None = None,
+        nearest_to: datetime | None = None,
+        layer: str | None = None,
+        where: str | None = None,
     ):
         super().__init__(
             _select_export(path, date, nearest_to), layer=layer, where=where
         )
 
 
-def _list_exports(source_dir: Path) -> List[Path]:
+def _list_exports(source_dir: Path) -> list[Path]:
     """All vector exports under a directory, child directories included.
 
     ``.gdb`` exports are directories on disk, so they are matched by
@@ -193,8 +193,8 @@ def _list_exports(source_dir: Path) -> List[Path]:
 
 def _select_export(
     path: str,
-    date: Optional[str],
-    nearest_to: Optional[datetime] = None,
+    date: str | None,
+    nearest_to: datetime | None = None,
 ) -> str:
     """Resolve a UNOSAT export path.
 
@@ -262,8 +262,9 @@ class RasterReferenceSource(ReferenceSource):
         # A WarpedVRT pinned to the requested window resolves CRS,
         # registration and out-of-bounds fill in one step; for a raster
         # already on the master grid this is a plain aligned read.
-        with rasterio.open(self.path) as src:
-            with WarpedVRT(
+        with (
+            rasterio.open(self.path) as src,
+            WarpedVRT(
                 src,
                 crs=crs,
                 transform=transform,
@@ -271,8 +272,9 @@ class RasterReferenceSource(ReferenceSource):
                 height=grid_shape[0],
                 resampling=Resampling.nearest,
                 nodata=0.0,
-            ) as vrt:
-                data = vrt.read(self.band).astype(np.float32)
+            ) as vrt,
+        ):
+            data = vrt.read(self.band).astype(np.float32)
         data[~np.isfinite(data)] = 0.0
         np.clip(data, 0.0, None, out=data)
         if clip_geom is not None:
@@ -288,7 +290,7 @@ class RasterReferenceSource(ReferenceSource):
 
 def rasterize_point_counts(
     gdf: gpd.GeoDataFrame,
-    out_shape: Tuple[int, int],
+    out_shape: tuple[int, int],
     transform: rasterio.Affine,
 ) -> np.ndarray:
     """Rasterize point geometries into counts per cell."""
@@ -326,9 +328,7 @@ def _infer_type(path: str) -> str:
     )
 
 
-def build_reference_source(
-    cfg, nearest_to: Optional[datetime] = None
-) -> ReferenceSource:
+def build_reference_source(cfg, nearest_to: datetime | None = None) -> ReferenceSource:
     """Build a :class:`ReferenceSource` from config.
 
     ``cfg`` is either a bare path (type inferred from the suffix) or a
@@ -343,8 +343,11 @@ def build_reference_source(
     """
     if isinstance(cfg, (str, Path)):
         cfg = {"path": str(cfg)}
+    # ValueError rather than the TypeError TRY004 asks for: every other
+    # rejection in this function raises ValueError, and callers catch config
+    # errors as one kind.
     if not isinstance(cfg, dict):
-        raise ValueError(
+        raise ValueError(  # noqa: TRY004
             "Reference config must be a path or a mapping with a 'path' key."
         )
     cfg = {k: v for k, v in cfg.items() if v is not None}

--- a/displacement_tracker/util/reference_data.py
+++ b/displacement_tracker/util/reference_data.py
@@ -343,9 +343,9 @@ def build_reference_source(cfg, nearest_to: datetime | None = None) -> Reference
     """
     if isinstance(cfg, (str, Path)):
         cfg = {"path": str(cfg)}
-    # ValueError rather than the TypeError TRY004 asks for: every other
-    # rejection in this function raises ValueError, and callers catch config
-    # errors as one kind.
+    # ValueError rather than the TypeError TRY004 asks for: the other two
+    # rejections below raise ValueError, and test_reference_data pins this one
+    # as ValueError as well.
     if not isinstance(cfg, dict):
         raise ValueError(  # noqa: TRY004
             "Reference config must be a path or a mapping with a 'path' key."

--- a/displacement_tracker/util/reference_data.py
+++ b/displacement_tracker/util/reference_data.py
@@ -343,11 +343,11 @@ def build_reference_source(cfg, nearest_to: datetime | None = None) -> Reference
     """
     if isinstance(cfg, (str, Path)):
         cfg = {"path": str(cfg)}
-    # ValueError rather than the TypeError TRY004 asks for: the other two
-    # rejections below raise ValueError, and test_reference_data pins this one
-    # as ValueError as well.
+    # TypeError, not ValueError: this rejects the wrong kind of thing rather
+    # than a bad value. The two rejections below stay ValueError — they take a
+    # well-formed mapping and fault its contents.
     if not isinstance(cfg, dict):
-        raise ValueError(  # noqa: TRY004
+        raise TypeError(
             "Reference config must be a path or a mapping with a 'path' key."
         )
     cfg = {k: v for k, v in cfg.items() if v is not None}

--- a/displacement_tracker/util/scan_orchestrator.py
+++ b/displacement_tracker/util/scan_orchestrator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import glob
 import os
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import rasterio
 

--- a/displacement_tracker/util/tile_builder.py
+++ b/displacement_tracker/util/tile_builder.py
@@ -38,7 +38,7 @@ def _compute_valid_fraction(data: np.ndarray, nodata) -> float:
 def tile_pixel_size(src, span_m: float) -> int:
     """Square tile side in pixels given a metric span and raster resolution."""
     px = abs(src.transform.a)
-    return int(round(span_m / px))
+    return round(span_m / px)
 
 
 def compute_tile_window(
@@ -98,8 +98,8 @@ def world_window(src, x: float, y: float, core_m: float, margin_m: float):
             return None
 
         col_f, row_f = (~src.transform) * (x, y)
-        r_center = int(round(row_f))
-        c_center = int(round(col_f))
+        r_center = round(row_f)
+        c_center = round(col_f)
 
         half = tile_px // 2
         r0 = max(0, min(r_center - half, src.height - tile_px))
@@ -127,8 +127,8 @@ def create_label_from_feats(
 
     for feat in feats:
         feat_lon, feat_lat = feat["geometry"]["coordinates"]
-        local_col = int(round((feat_lon - lon_min) / lon_span * (w - 1)))
-        local_row = int(round((lat_max - feat_lat) / lat_span * (h - 1)))
+        local_col = round((feat_lon - lon_min) / lon_span * (w - 1))
+        local_row = round((lat_max - feat_lat) / lat_span * (h - 1))
 
         for dr in (-1, 0, 1):
             for dc in (-1, 0, 1):
@@ -163,8 +163,8 @@ def _read_prewar_tile(
         lat_c = 0.5 * (lat_min + lat_max)
         pxs, pys = transform("EPSG:4326", prewar_src.crs, [lon_c], [lat_c])
         col_f, row_f = (~prewar_src.transform) * (pxs[0], pys[0])
-        r_center = int(round(row_f))
-        c_center = int(round(col_f))
+        r_center = round(row_f)
+        c_center = round(col_f)
 
         half = tile_px // 2
         rpre0 = max(0, min(r_center - half, prewar_src.height - tile_px))

--- a/displacement_tracker/util/train_metadata_embedding.py
+++ b/displacement_tracker/util/train_metadata_embedding.py
@@ -23,9 +23,8 @@ from typing import Any
 
 import click
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
-import torch.optim as optim
+from torch import nn, optim
 from torch.utils.data import DataLoader
 
 from displacement_tracker.paired_image_dataset import PairedImageDataset

--- a/displacement_tracker/util/validation_core.py
+++ b/displacement_tracker/util/validation_core.py
@@ -8,7 +8,6 @@ hull.
 
 import os
 from pathlib import Path
-from typing import Dict, List, Tuple
 
 import geopandas as gpd
 import numpy as np
@@ -23,9 +22,8 @@ from displacement_tracker.util.thresholding import (
     rescale_adjusted_peak,
 )
 
-
 # Direction of optimization for each metric: "min" = lower is better.
-METRIC_DIRECTIONS: Dict[str, str] = {
+METRIC_DIRECTIONS: dict[str, str] = {
     "rms": "min",
     "mae": "min",
     "rmsle": "min",
@@ -35,7 +33,7 @@ METRIC_DIRECTIONS: Dict[str, str] = {
 }
 
 
-def list_point_files(directory: str) -> List[str]:
+def list_point_files(directory: str) -> list[str]:
     """Sorted point-set files (predictions) in a directory."""
     return sorted(
         os.path.join(directory, f)
@@ -49,7 +47,7 @@ def prepare_grouped_cell_inputs(
     reference: ReferenceSource,
     src_grid: rasterio.io.DatasetReader,
     nodata_val: float = -9999.0,
-) -> Dict[str, object]:
+) -> dict[str, object]:
     """Build one-time geometry/grid products and per-point cell assignments."""
     prediction_extent_geom = pred_gdf.union_all().convex_hull
 
@@ -104,9 +102,9 @@ def process_grouped_cells(
     pred_cols: np.ndarray,
     val_raster: np.ndarray,
     mask_array: np.ndarray,
-    grid_shape: Tuple[int, int],
+    grid_shape: tuple[int, int],
     nodata_val: float = -9999.0,
-) -> Dict[str, np.ndarray]:
+) -> dict[str, np.ndarray]:
     """Build a prediction raster from pre-grouped cells and derive diff/error rasters.
 
     `val_raster` is mutated in place to hold `nodata_val` outside the mask, so the
@@ -148,7 +146,7 @@ def compute_metrics(
     val_raster: np.ndarray,
     error_raster: np.ndarray,
     mask_array: np.ndarray,
-) -> Dict[str, float]:
+) -> dict[str, float]:
     """Compute per-tile error metrics restricted to the analysis mask."""
     pred_in = pred_raster[mask_array]
     val_in = val_raster[mask_array]
@@ -198,7 +196,7 @@ def write_output_rasters(
     val_raster: np.ndarray,
     diff_masked: np.ndarray,
     src_grid: rasterio.io.DatasetReader,
-    grid_shape: Tuple[int, int],
+    grid_shape: tuple[int, int],
     out_transform: rasterio.Affine,
     nodata_val: float = -9999.0,
 ) -> None:

--- a/displacement_tracker/visualization/dataset_viewer.py
+++ b/displacement_tracker/visualization/dataset_viewer.py
@@ -1,9 +1,10 @@
 import json
-import torch
-import numpy as np
-import matplotlib.pyplot as plt
-import matplotlib.patheffects as pe
 import random
+
+import matplotlib.patheffects as pe
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
 
 
 class DatasetViewer:
@@ -82,7 +83,7 @@ class DatasetViewer:
     def show_overlay(self, idx: int) -> None:
         arr_feat, arr_prewar, arr_label, meta_text = self._prepare_display_data(idx)
 
-        fig, axes = plt.subplots(
+        _fig, axes = plt.subplots(
             1,
             3,
             figsize=(30, 8),  # bigger figure
@@ -112,7 +113,7 @@ class DatasetViewer:
         if diff_vis.max() > 0:
             diff_vis /= diff_vis.max()
 
-        fig, axes = plt.subplots(
+        _fig, axes = plt.subplots(
             1,
             5,
             figsize=(30, 8),  # bigger figure
@@ -171,7 +172,7 @@ class DatasetViewer:
                 best_scale = scale
 
         figsize = (best_cols * best_scale, best_rows * best_scale)
-        fig, axes = plt.subplots(best_rows, best_cols, figsize=figsize)
+        _fig, axes = plt.subplots(best_rows, best_cols, figsize=figsize)
 
         if not isinstance(axes, np.ndarray):
             axes = np.array([axes])

--- a/poetry.lock
+++ b/poetry.lock
@@ -3120,30 +3120,30 @@ pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruff"
-version = "0.15.4"
+version = "0.16.0"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0"},
-    {file = "ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992"},
-    {file = "ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec"},
-    {file = "ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f"},
-    {file = "ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338"},
-    {file = "ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc"},
-    {file = "ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68"},
-    {file = "ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3"},
-    {file = "ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22"},
-    {file = "ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f"},
-    {file = "ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453"},
-    {file = "ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1"},
+    {file = "ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e"},
+    {file = "ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522"},
+    {file = "ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b"},
+    {file = "ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09"},
+    {file = "ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed"},
+    {file = "ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb"},
+    {file = "ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472"},
+    {file = "ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d"},
+    {file = "ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982"},
 ]
 
 [[package]]
@@ -4218,4 +4218,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "a9c38dd9409223cdf7090524129b42a52c0d889ccc4d993dab4dd27fb8d6edf5"
+content-hash = "23898313afb0575a30a8e6d7b6a5e99e7fe6701a44d0806f58ad54a0f935e6d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
-    "ruff (>=0.15.0,<0.16.0)",
+    "ruff (>=0.16.0,<0.17.0)",
     "remote-plot (>=1.2.1,<2.0.0)",
     "pytest (>=9.1.1,<10.0.0)"
 ]
@@ -106,3 +106,32 @@ test = [
 
 [tool.poetry.group.ui]
 optional = true
+
+[tool.ruff]
+# `[project]` carries no `requires-python`, so ruff cannot infer the floor and
+# would fall back to its own default. State it here instead of adding
+# `requires-python` alongside `[tool.poetry.dependencies].python`, which would
+# give Poetry two sources for the same constraint.
+target-version = "py310"
+
+[tool.ruff.lint]
+# ruff 0.16 turned on 413 rules by default, up from 59. The expanded set is
+# adopted as-is apart from the families below, each of which flags a deliberate
+# pattern in this pipeline rather than a defect.
+ignore = [
+    # Blind `except Exception` is the fault-isolation strategy for the batch
+    # stages: one corrupt TIFF, tile or prediction date is skipped and logged
+    # so the rest of the run still completes. Narrowing these would let a
+    # single bad input abort a multi-hour scan.
+    "BLE001",
+    # Naive datetimes are correct here. Every parsed value is a calendar
+    # acquisition date lifted out of a filename (`YYYYMMDD`), not an instant,
+    # and the `datetime.now()` calls only stamp run directories in local time.
+    "DTZ001",
+    "DTZ005",
+    "DTZ007",
+    # The silent handlers this flags are best-effort cleanup — shutting down an
+    # already-broken executor, unlinking a temp file, closing raster handles, a
+    # UI stats widget. There is nothing actionable to log.
+    "S110",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,9 @@ import os
 # Importing the evaluation plot modules must not need a display.
 os.environ.setdefault("MPLBACKEND", "Agg")
 
-import pytest  # noqa: E402
+import pytest
 
-from displacement_tracker.util import reference_data  # noqa: E402
+from displacement_tracker.util import reference_data
 
 # ``reference_data.SOURCE_TYPES`` is a module-level dict that any importer
 # may extend: importing ``evaluation.annotation_reference`` registers the

--- a/tests/test_add_new_model_results.py
+++ b/tests/test_add_new_model_results.py
@@ -5,10 +5,10 @@ import numpy as np
 import pandas as pd
 import pytest
 import rasterio
-from shapely.geometry import Point
-
 from _helpers import CRS_UTM as UTM
 from _helpers import annotation_header, utm_to_lonlat, write_geotiff
+from shapely.geometry import Point
+
 from displacement_tracker.evaluation.scripts.add_new_model_results import (
     _unique_column_name,
     add_new_model_results,

--- a/tests/test_annotation_reference.py
+++ b/tests/test_annotation_reference.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 import pytest
+from _helpers import CRS_UTM, CRS_WGS84, utm_to_lonlat, write_annotation_csv
 from rasterio.transform import from_origin
 from shapely.geometry import box
 
-from _helpers import CRS_UTM, CRS_WGS84, utm_to_lonlat, write_annotation_csv
 from displacement_tracker.evaluation.annotation_reference import (
     ManualAnnotationReferenceSource,
     _select_date,

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -17,8 +17,8 @@ degrees. At base latitude 0 these constructions are float-exact.
 import math
 
 import pytest
-
 from _helpers import DEG_PER_M, EARTH_RADIUS_M
+
 from displacement_tracker.util.deduplication import UnionFind, merge_close_points_global
 from displacement_tracker.util.distance import haversine_m, interpolate_centroid
 

--- a/tests/test_merge_geojsons.py
+++ b/tests/test_merge_geojsons.py
@@ -5,9 +5,9 @@ import json
 import click
 import geopandas as gpd
 import pytest
+from _helpers import write_geojson
 from shapely.geometry import Point, box
 
-from _helpers import write_geojson
 from displacement_tracker.h_merge_geojsons import (
     MERGE_CONFIG_KEYS,
     filter_points_by_zone,
@@ -32,15 +32,15 @@ NEAR_DEG = 1e-5
 
 def default_merge_kwargs(**overrides):
     """Baseline kwargs for process_geojson_folder with no filtering active."""
-    kwargs = dict(
-        min_distance_m=3.0,
-        agreement=1,
-        min_adj_peak=0.0,
-        adjustment_factor=1.0,
-        thresholds_data={},
-        exclusion_geom=None,
-        inclusion_geom=None,
-    )
+    kwargs = {
+        "min_distance_m": 3.0,
+        "agreement": 1,
+        "min_adj_peak": 0.0,
+        "adjustment_factor": 1.0,
+        "thresholds_data": {},
+        "exclusion_geom": None,
+        "inclusion_geom": None,
+    }
     kwargs.update(overrides)
     return kwargs
 

--- a/tests/test_merge_tuned.py
+++ b/tests/test_merge_tuned.py
@@ -3,9 +3,9 @@
 import click
 import geopandas as gpd
 import pytest
+from _helpers import write_geojson, write_yaml
 from click.testing import CliRunner
 
-from _helpers import write_geojson, write_yaml
 from displacement_tracker.h2_merge_tuned import cli, load_best_params
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -21,13 +21,13 @@ from displacement_tracker.pipelines.spec import PREDICT, TRAIN, TUNE, Pipeline
 
 
 def _make_pipeline(**kwargs) -> Pipeline:
-    defaults = dict(
-        key="predict",
-        label="Test pipeline",
-        base_config="config.yaml",
-        stages=(),
-        params=(),
-    )
+    defaults = {
+        "key": "predict",
+        "label": "Test pipeline",
+        "base_config": "config.yaml",
+        "stages": (),
+        "params": (),
+    }
     defaults.update(kwargs)
     return Pipeline(**defaults)
 

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -12,10 +12,10 @@ import geopandas as gpd
 import numpy as np
 import pytest
 import rasterio
+from _helpers import CRS_UTM, CRS_WGS84, write_geotiff
 from rasterio.transform import from_origin
 from shapely.geometry import Point, box
 
-from _helpers import CRS_UTM, CRS_WGS84, write_geotiff
 from displacement_tracker.util.reference_data import (
     PointsSource,
     RasterReferenceSource,

--- a/tests/test_reference_data.py
+++ b/tests/test_reference_data.py
@@ -672,8 +672,10 @@ def test_build_reference_source_rejects_a_non_mapping_config():
     not_a_mapping = 42
 
     # When: build_reference_source validates it
-    # Then: ValueError says what the config is allowed to be
-    with pytest.raises(ValueError, match="path or a mapping"):
+    # Then: TypeError says what the config is allowed to be — the wrong kind of
+    #       thing entirely, unlike the ValueError rejections of a mapping whose
+    #       contents are at fault
+    with pytest.raises(TypeError, match="path or a mapping"):
         build_reference_source(not_a_mapping)
 
 

--- a/tests/test_scan_orchestrator.py
+++ b/tests/test_scan_orchestrator.py
@@ -17,7 +17,6 @@ from displacement_tracker.util.scan_orchestrator import (
     run_scans,
 )
 
-
 # ---------------------------------------------------------------------------
 # scan_orchestrator.collect_tif_files
 # ---------------------------------------------------------------------------

--- a/tests/test_scan_validation.py
+++ b/tests/test_scan_validation.py
@@ -30,23 +30,23 @@ from displacement_tracker.util.validation_core import initial_best_value, is_bet
 
 
 def _settings(**overrides) -> ScanSettings:
-    base = dict(
-        input_path="merged_raw.gpkg",
-        pred_folder=None,
-        master_grid="grid.tif",
-        reference={"path": "ref.geojson"},
-        out_dir="scan_results",
-        best_params_path="scan_results/best_params.yaml",
-        metric="rms",
-        scan_metrics=["rms"],
-        factor_bounds=(0.0, 10.0),
-        cutoff_bounds=(0.0001, 0.01),
-        ridge_probes=5,
-        xtol_factor=1e-3,
-        xtol_cutoff=1e-6,
-        refine_maxiter=60,
-        exclusion_zones=None,
-    )
+    base = {
+        "input_path": "merged_raw.gpkg",
+        "pred_folder": None,
+        "master_grid": "grid.tif",
+        "reference": {"path": "ref.geojson"},
+        "out_dir": "scan_results",
+        "best_params_path": "scan_results/best_params.yaml",
+        "metric": "rms",
+        "scan_metrics": ["rms"],
+        "factor_bounds": (0.0, 10.0),
+        "cutoff_bounds": (0.0001, 0.01),
+        "ridge_probes": 5,
+        "xtol_factor": 1e-3,
+        "xtol_cutoff": 1e-6,
+        "refine_maxiter": 60,
+        "exclusion_zones": None,
+    }
     base.update(overrides)
     return ScanSettings(**base)
 


### PR DESCRIPTION
[ruff 0.16](https://astral.sh/blog/ruff-v0.16.0) (released 2026-07-23) **enables 413 rules by default, up from 59**. The tree is clean under 0.15 and picks up **246 findings** under the new defaults, so the pin cannot move without this.

Rebased onto `Karim` now that #40 and #50 have landed — no longer stacked on anything, so the diff is this PR's own work only.

## The version bump

`pyproject.toml` dev group and the `Install ruff` step in `ci.yml` both move to `>=0.16.0,<0.17.0`, kept in step as the existing comment asks.

`poetry.lock` is regenerated. This is load-bearing, not housekeeping: `poetry check --lock` fails on the changed constraint, and CI's test job runs `poetry install --only test --no-root`, which refuses a stale lock — so without the re-lock the test job dies before the linter ever runs. The lock diff is exactly ruff 0.15.4 → 0.16.0.

## What was adopted, and what wasn't

The expanded set is taken as-is apart from three families, each ignored in a new `[tool.ruff.lint]` block with its reason inline. Each flags a deliberate pattern rather than a defect:

| Ignored | Sites | Why |
|---|---|---|
| `BLE001` | 19 | Blind `except Exception` is the fault-isolation strategy for the batch stages — one corrupt TIFF, tile or prediction date is skipped and logged so a multi-hour scan still completes. This is the behavior #41 wrote tests for. |
| `DTZ001/005/007` | 22 | Every parsed value is a calendar acquisition date lifted out of a filename (`YYYYMMDD`), not an instant; the `datetime.now()` calls only stamp run directories in local time. |
| `S110` | 6 | I read all of them. They are best-effort cleanup — shutting down an already-broken executor, unlinking a temp file, closing raster handles, a UI stats widget. There is nothing actionable to log. |

`S112` is deliberately **not** ignored alongside `S110`, though it fired before #40: its one site was the `try`/`except`/`continue` in `b_coordinate_scanner`, which #40 deleted. An ignore for a rule that no longer fires is dead config that would quietly permit the pattern in new code. Every rule in the list above was re-checked against the rebased tree and still fires.

`target-version` is set to `py310` because `[project]` carries no `requires-python`, so ruff would otherwise fall back to its own default. I did **not** add `requires-python` to `[project]`, which would give Poetry a second source for the constraint already in `[tool.poetry.dependencies]` — `poetry check` warns about that split today and I did not want to deepen it.

## The fixes

**Mechanical: 179 from `ruff check --fix`, 25 more from the unsafe fixes** for `RUF046`, `C408`, `RUF059`, `SIM117`, `SIM118`, `SIM102` — PEP 585/604 annotations, import sorting, `dict()` calls to literals.

`RUF046` was checked rather than assumed. Dropping the `int()` from `int(round(x))` looked risky in `tile_builder`, where the results index arrays and several operands are numpy scalars — a leaked `np.float64` would raise `IndexError` at the use site. `round()` in fact returns a real `int` for `np.float64` as well as `float`, so the fix is safe; the unquoted annotations (`UP037`) were likewise confirmed to sit in files that already carry `from __future__ import annotations`.

**Eight needed a judgment call:**

- `d_train_cnn` — `raise Exception` for an unknown device becomes `ValueError`.
- `e_predict_json` — the temp NDJSON file must outlive its block, so there is no context manager to open; `NamedTemporaryFile(delete=False)` + `close()` becomes `mkstemp`, which is the API for precisely that.
- `manual_eval`, `pipelines/app` — nested `with` statements combined. The `manual_eval` hunk looks large; `git diff -w` reduces it to 8 lines, the rest being re-indentation.
- `simple_cnn` — `ALLOWED_KWARGS` annotated `ClassVar`. The deliberate `x = x` that keeps the trained checkpoint loadable gets a `noqa` rather than a rewrite; that line is load-bearing for checkpoint compatibility and is not worth touching for a lint rule.
- `manifest_writer` — `PYI034` wants `Self`, which `typing` only gained in 3.11 against a 3.10 floor. Annotation stays, suppressed with the reason.
- `reference_data` — `TRY004`, the one genuine behavior change; see below.

The two remaining `noqa`s (`PLW0127`, `PYI034`) were confirmed live under `--extend-select RUF100`.

## `TRY004`: the one behavior change

`build_reference_source` rejected a config that is neither a path nor a mapping with `ValueError`. It now raises `TypeError`, which is what the rule asks for and the right reading here — that guard rejects the *wrong kind of thing*, where the two rejections below it (missing `path`, unknown `type`) take a well-formed mapping and fault its contents. Those stay `ValueError`.

`test_build_reference_source_rejects_a_non_mapping_config` pinned the old type and moves with it, carrying a note on why this rejection differs from its neighbours.

Nothing catches this exception — neither `g1_scan_validation.py:534` nor `g2_validate_geojson.py:141` wraps the call — so it reaches users only as the exception name printed for a malformed config.

I first suppressed this one and flagged it for review; the last two commits are the correction and then the fix, kept separate so the reasoning is legible.

## The #50 re-lint

One commit covers the test files that arrived with #50 (#49, #43, #44, #45), which had never seen ruff 0.16 — 33 findings across four test files plus `g1_scan_validation`, all mechanical.

`g1_scan_validation` was the one rebase conflict: #43 promoted its private seams to public while this branch was rewriting its annotations. Resolved by taking `Karim`'s version wholesale and re-deriving the lint fixes on top rather than merging hunks — the change there is purely mechanical, so re-running the fixer is safer than reconciling by hand. #43's seven promoted names (`ScanSettings.from_config`, `make_evaluator`, `objective`, `optimize_metric`, `prediction_date`, `resolve_metrics`, `write_best_params`) are all verified intact.

## Formatter

0.16 formats Python code blocks in Markdown by default. That turned out to be a non-event here — the Markdown files were already clean, so there is no doc churn in this diff.

## Verification

Run on the rebased tree: `ruff check .` clean (and clean under `--extend-select RUF100`), `ruff format --check .` clean, **231 tests pass**, `compileall` clean over `displacement_tracker` and `tests`, and `poetry check --lock` passes.

Not run here: nothing behavioral needs a data share. The non-mechanical runtime changes are the `mkstemp` swap, the `Exception` → `ValueError` raise in `d_train_cnn`, and the `TRY004` change above. Worth an eye on the `mkstemp` hunk in review — it is in the predict path, which the suite does not cover.