### PR TITLE
Merge the stranded half of the test stack into Karim (#49, #43, #44, #45)

### DIFF
--- a/displacement_tracker/g1_scan_validation.py
+++ b/displacement_tracker/g1_scan_validation.py
@@ -75,7 +75,7 @@ def _budget_per_metric(n_probes: int, refine_maxiter: int) -> int:
     return n_probes * BRENT_EVAL_BUDGET + BRENT_EVAL_BUDGET + max(refine_maxiter, 0)
 
 
-def _make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
+def make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
     """Return an evaluate(factor, cutoff) -> metrics function.
 
     Side effects: every call appends to `trace`, updates `bests[m]` for any
@@ -132,7 +132,7 @@ def _make_evaluator(grouped, scan_metrics, bests, trace, progress=None):
     return evaluate
 
 
-def _objective(evaluate: Callable, metric: str, factor: float, cutoff: float) -> float:
+def objective(evaluate: Callable, metric: str, factor: float, cutoff: float) -> float:
     """Sign-adjusted scalar objective (always minimized) with penalty on failure."""
     metrics = evaluate(factor, cutoff)
     if metrics is None:
@@ -143,7 +143,7 @@ def _objective(evaluate: Callable, metric: str, factor: float, cutoff: float) ->
     return float(v) if METRIC_DIRECTIONS[metric] == "min" else float(-v)
 
 
-def _optimize_metric(
+def optimize_metric(
     evaluate: Callable,
     metric: str,
     bests: Dict[str, dict],
@@ -167,7 +167,7 @@ def _optimize_metric(
     ridge_pts: List[Tuple[float, float]] = []
     for f in probe_factors:
         res = minimize_scalar(
-            lambda c, _f=float(f): _objective(evaluate, metric, _f, c),
+            lambda c, _f=float(f): objective(evaluate, metric, _f, c),
             bounds=(cb_lo, cb_hi),
             method="bounded",
             options={"xatol": xtol_cutoff},
@@ -185,7 +185,7 @@ def _optimize_metric(
     # --- Phase 3: 1-D search along the fitted ridge ---
     def along_ridge(f: float) -> float:
         c = float(np.clip(a * f + b, cb_lo, cb_hi))
-        return _objective(evaluate, metric, f, c)
+        return objective(evaluate, metric, f, c)
 
     minimize_scalar(
         along_ridge,
@@ -202,7 +202,7 @@ def _optimize_metric(
         def obj2d(x):
             f = float(np.clip(x[0], fb_lo, fb_hi))
             c = float(np.clip(x[1], cb_lo, cb_hi))
-            return _objective(evaluate, metric, f, c)
+            return objective(evaluate, metric, f, c)
 
         minimize(
             obj2d,
@@ -247,10 +247,10 @@ def scan_tile(
     }
     trace: List[Dict[str, float]] = []
 
-    evaluate = _make_evaluator(grouped, scan_metrics, bests, trace, progress=progress)
+    evaluate = make_evaluator(grouped, scan_metrics, bests, trace, progress=progress)
     ridges: Dict[str, Tuple[float, float]] = {}
     for m in scan_metrics:
-        a, b = _optimize_metric(
+        a, b = optimize_metric(
             evaluate=evaluate,
             metric=m,
             bests=bests,
@@ -327,7 +327,7 @@ def plot_search_trace(
     plt.close(fig)
 
 
-def _resolve_metrics(tuning_cfg: dict) -> Tuple[str, List[str]]:
+def resolve_metrics(tuning_cfg: dict) -> Tuple[str, List[str]]:
     """Return (eval metric, metrics to track); the eval metric is always tracked."""
     metric = tuning_cfg.get("metric", "rms")
     metrics = list(tuning_cfg.get("metrics") or SCAN_METRICS_DEFAULT)
@@ -372,54 +372,55 @@ class ScanSettings:
     def base_name(self) -> str:
         return os.path.splitext(os.path.basename(self.input_path))[0]
 
+    @classmethod
+    def from_config(cls, params: dict) -> "ScanSettings":
+        """Extract and validate the scan settings from a resolved (flat) config."""
+        tuning = params.get("tuning") or {}
+        merge_cfg = params.get("merge") or {}
 
-def _scan_settings(params: dict) -> ScanSettings:
-    """Extract and validate the scan settings from a resolved (flat) config."""
-    tuning = params.get("tuning") or {}
-    merge_cfg = params.get("merge") or {}
+        input_path = tuning.get("input") or merge_cfg.get("output")
+        if not input_path:
+            raise click.ClickException(
+                "Missing required config key: tuning.input "
+                "(or merge.output as fallback)"
+            )
+        out_dir = tuning.get("out_dir") or "scan_results"
+        metric, scan_metrics = resolve_metrics(tuning)
 
-    input_path = tuning.get("input") or merge_cfg.get("output")
-    if not input_path:
-        raise click.ClickException(
-            "Missing required config key: tuning.input (or merge.output as fallback)"
+        factor_bounds = (
+            float(tuning.get("factor_min", 0.0)),
+            float(tuning.get("factor_max", 10.0)),
         )
-    out_dir = tuning.get("out_dir") or "scan_results"
-    metric, scan_metrics = _resolve_metrics(tuning)
+        cutoff_bounds = (
+            float(tuning.get("cutoff_min", 0.0001)),
+            float(tuning.get("cutoff_max", 0.01)),
+        )
+        if factor_bounds[0] >= factor_bounds[1] or cutoff_bounds[0] >= cutoff_bounds[1]:
+            raise click.ClickException(
+                "tuning.factor_min/cutoff_min must be strictly less than their max."
+            )
 
-    factor_bounds = (
-        float(tuning.get("factor_min", 0.0)),
-        float(tuning.get("factor_max", 10.0)),
-    )
-    cutoff_bounds = (
-        float(tuning.get("cutoff_min", 0.0001)),
-        float(tuning.get("cutoff_max", 0.01)),
-    )
-    if factor_bounds[0] >= factor_bounds[1] or cutoff_bounds[0] >= cutoff_bounds[1]:
-        raise click.ClickException(
-            "tuning.factor_min/cutoff_min must be strictly less than their max."
+        return cls(
+            input_path=input_path,
+            pred_folder=merge_cfg.get("input_folder"),
+            master_grid=_require(tuning, "tuning", "master_grid"),
+            reference=_require(tuning, "tuning", "reference"),
+            out_dir=out_dir,
+            best_params_path=tuning.get("best_params")
+            or os.path.join(out_dir, "best_params.yaml"),
+            metric=metric,
+            scan_metrics=scan_metrics,
+            factor_bounds=factor_bounds,
+            cutoff_bounds=cutoff_bounds,
+            ridge_probes=int(tuning.get("ridge_probes", 5)),
+            xtol_factor=float(tuning.get("xtol_factor", 1e-3)),
+            xtol_cutoff=float(tuning.get("xtol_cutoff", 1e-6)),
+            refine_maxiter=int(tuning.get("refine_maxiter", 60)),
+            exclusion_zones=tuning.get("exclusion_zones"),
         )
 
-    return ScanSettings(
-        input_path=input_path,
-        pred_folder=merge_cfg.get("input_folder"),
-        master_grid=_require(tuning, "tuning", "master_grid"),
-        reference=_require(tuning, "tuning", "reference"),
-        out_dir=out_dir,
-        best_params_path=tuning.get("best_params")
-        or os.path.join(out_dir, "best_params.yaml"),
-        metric=metric,
-        scan_metrics=scan_metrics,
-        factor_bounds=factor_bounds,
-        cutoff_bounds=cutoff_bounds,
-        ridge_probes=int(tuning.get("ridge_probes", 5)),
-        xtol_factor=float(tuning.get("xtol_factor", 1e-3)),
-        xtol_cutoff=float(tuning.get("xtol_cutoff", 1e-6)),
-        refine_maxiter=int(tuning.get("refine_maxiter", 60)),
-        exclusion_zones=tuning.get("exclusion_zones"),
-    )
 
-
-def _prediction_date(settings: ScanSettings):
+def prediction_date(settings: ScanSettings):
     """Median date stamped on the pre-merge prediction files (None if unknown).
 
     Feeds unosat auto-discovery when reference.date is not set; the merged
@@ -492,7 +493,7 @@ def _write_summary_csv(settings: ScanSettings, bests, ridges, trace, final_metri
     click.echo(f"Summary saved to: {summary_path}")
 
 
-def _write_best_params(settings: ScanSettings, bests, chosen) -> dict:
+def write_best_params(settings: ScanSettings, bests, chosen) -> dict:
     # The merge stage names the pair (adjustment_factor, min_adj_peak);
     # h2_merge_tuned reads exactly these keys back.
     best_params = {
@@ -528,10 +529,10 @@ def run_scan(params: dict) -> dict:
     ``scan_summary.csv``, best-parameter rasters and ``best_params.yaml``
     into ``tuning.out_dir``, and returns the tuned parameters.
     """
-    settings = _scan_settings(params)
+    settings = ScanSettings.from_config(params)
     os.makedirs(settings.out_dir, exist_ok=True)
     reference = build_reference_source(
-        settings.reference, nearest_to=_prediction_date(settings)
+        settings.reference, nearest_to=prediction_date(settings)
     )
 
     total_evals = _budget_per_metric(
@@ -587,7 +588,7 @@ def run_scan(params: dict) -> dict:
         final_metrics = _export_best(settings, grouped, chosen, src_grid)
 
     _write_summary_csv(settings, bests, ridges, trace, final_metrics)
-    return _write_best_params(settings, bests, chosen)
+    return write_best_params(settings, bests, chosen)
 
 
 @click.command()

--- a/tests/test_add_new_model_results.py
+++ b/tests/test_add_new_model_results.py
@@ -1,0 +1,278 @@
+"""Tests for displacement_tracker/evaluation/scripts/add_new_model_results.py."""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+import rasterio
+from shapely.geometry import Point
+
+from _helpers import CRS_UTM as UTM
+from _helpers import annotation_header, utm_to_lonlat, write_geotiff
+from displacement_tracker.evaluation.scripts.add_new_model_results import (
+    _unique_column_name,
+    add_new_model_results,
+)
+
+# Two tile centroids in UTM 36N, 1 km apart. Their 100 m tiles span
+# [x-50, x+50] x [y-50, y+50].
+C1 = (500000.0, 3474000.0)
+C2 = (501000.0, 3474000.0)
+
+
+def lonlat(xy):
+    return utm_to_lonlat(xy[0], xy[1])
+
+
+def write_annotation_csv(path, rows):
+    """rows: list of (date, utm_xy) — centroid stored as WGS84 lat/lon."""
+    lines = [annotation_header()]
+    for date, xy in rows:
+        lon, lat = lonlat(xy)
+        lines.append(f"{date},{lat},{lon},1\n")
+    path.write_text("".join(lines))
+    return str(path)
+
+
+def write_sample_tif(path, crs=UTM):
+    """A 1x1 placeholder raster; only its CRS and transform are read."""
+    return write_geotiff(
+        path,
+        np.zeros((1, 1), dtype=np.float32),
+        rasterio.transform.from_origin(500000.0, 3474000.0, 1.0, 1.0),
+        crs=crs,
+    )
+
+
+def write_predictions(path, utm_points, crs=UTM):
+    """Write prediction points given as UTM coordinates, in the given CRS."""
+    if crs == UTM:
+        geoms = [Point(x, y) for x, y in utm_points]
+    else:
+        geoms = [Point(*lonlat(p)) for p in utm_points]
+    gpd.GeoDataFrame(geometry=geoms, crs=crs).to_file(path, driver="GPKG")
+    return str(path)
+
+
+# ==========================================================
+# _unique_column_name
+# ==========================================================
+
+
+def test_unique_column_name_collision_fallback():
+    # Given: a frame that already has columns "m" and "m_1"
+    df = pd.DataFrame(columns=["m", "m_1"])
+
+    # When: a unique name is requested for the taken base "m"
+    taken = _unique_column_name(df, "m")
+
+    # Then: it falls back to the first free suffix, "m_2"
+    assert taken == "m_2"
+
+    # When: a unique name is requested for the absent base "x"
+    free = _unique_column_name(df, "x")
+
+    # Then: "x" is used as-is
+    assert free == "x"
+
+
+# ==========================================================
+# add_new_model_results
+# ==========================================================
+
+
+def test_counts_points_within_reconstructed_100m_tiles(tmp_path):
+    # Given: two annotated tiles (centroids C1 and C2, 100 m tiles = +/-50 m
+    #        boxes); the date's predictions hold 3 points strictly inside C1's
+    #        tile (offsets (10,10), (-49,0), (0,49)), one point 60 m east of C1
+    #        (outside both tiles), and none near C2
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-10-14", C2)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(
+        pred_dir / "20241014.gpkg",
+        [
+            (C1[0] + 10, C1[1] + 10),
+            (C1[0] - 49, C1[1]),
+            (C1[0], C1[1] + 49),
+            (C1[0] + 60, C1[1]),
+        ],
+    )
+
+    # When: add_new_model_results joins the predictions onto the annotations
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: C1's tile counts 3, C2's tile counts 0, and the manual column is
+    #       preserved unchanged in the written CSV
+    assert column == "new_model"
+    result = pd.read_csv(out_csv)
+    assert result["new_model"].tolist() == [3, 0]
+    assert result["manual_tent_count"].tolist() == [1, 1]
+
+
+def test_predictions_are_matched_per_date_file(tmp_path):
+    # Given: two annotation rows at the SAME centroid C1 but different dates;
+    #        20241014.gpkg holds 2 points inside the tile and 20241101.gpkg
+    #        holds 5
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-11-01", C1)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    inside = (C1[0] + 5, C1[1] - 5)
+    write_predictions(pred_dir / "20241014.gpkg", [inside] * 2)
+    write_predictions(pred_dir / "20241101.gpkg", [inside] * 5)
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: each row is counted only against its own date's file: [2, 5]
+    result = pd.read_csv(out_csv)
+    assert result.loc[result["date"] == "2024-10-14", column].tolist() == [2]
+    assert result.loc[result["date"] == "2024-11-01", column].tolist() == [5]
+
+
+def test_lonlat_predictions_reprojected_to_raster_crs(tmp_path):
+    # Given: prediction points stored in EPSG:4326 (converted from UTM offsets
+    #        (10,10) and (-30,20) inside C1's tile) while the sample tif is UTM
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(
+        pred_dir / "20241014.gpkg",
+        [(C1[0] + 10, C1[1] + 10), (C1[0] - 30, C1[1] + 20)],
+        crs="EPSG:4326",
+    )
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: predictions are reprojected before the spatial join, so both count
+    assert pd.read_csv(out_csv)[column].tolist() == [2]
+
+
+def test_missing_prediction_file_yields_na_only_for_that_date(tmp_path):
+    # Given: annotations on 2024-10-14 (predictions present, 1 point inside)
+    #        and 2024-11-01 (no gpkg on disk)
+    ann = write_annotation_csv(
+        tmp_path / "ann.csv", [("2024-10-14", C1), ("2024-11-01", C1)]
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(pred_dir / "20241014.gpkg", [(C1[0], C1[1])])
+
+    # When: add_new_model_results runs
+    out_csv, column = add_new_model_results(
+        annotation_csv=ann,
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: the October row gets its count and the November row is NA,
+    #       not zero — absence of a file is not "zero tents"
+    result = pd.read_csv(out_csv)
+    assert result.loc[result["date"] == "2024-10-14", column].tolist() == [1]
+    assert result.loc[result["date"] == "2024-11-01", column].isna().all()
+
+
+def test_column_name_collision_appends_suffix_and_keeps_original(tmp_path):
+    # Given: the annotation CSV already carries a column named "new_model"
+    #        with value 42
+    ann_path = tmp_path / "ann.csv"
+    lon, lat = lonlat(C1)
+    ann_path.write_text(
+        "date,latitude,longitude,manual_tent_count,new_model\n"
+        f"2024-10-14,{lat},{lon},1,42\n"
+    )
+    tif = write_sample_tif(tmp_path / "sample.tif")
+    pred_dir = tmp_path / "preds"
+    pred_dir.mkdir()
+    write_predictions(pred_dir / "20241014.gpkg", [(C1[0], C1[1])])
+
+    # When: add_new_model_results is asked to add "new_model" again
+    out_csv, column = add_new_model_results(
+        annotation_csv=str(ann_path),
+        output_csv=str(tmp_path / "out.csv"),
+        prediction_dir=str(pred_dir),
+        sample_tif=tif,
+        new_model_column="new_model",
+    )
+
+    # Then: the counts land in "new_model_1" and the original column's value
+    #       survives untouched
+    assert column == "new_model_1"
+    result = pd.read_csv(out_csv)
+    assert result["new_model"].tolist() == [42]
+    assert result["new_model_1"].tolist() == [1]
+
+
+def test_missing_inputs_raise_file_not_found(tmp_path):
+    # Given: no annotation CSV at the path handed to the function
+    # When: add_new_model_results runs
+    # Then: the precondition fails fast with FileNotFoundError naming the
+    #       annotation input
+    with pytest.raises(FileNotFoundError, match="annotation"):
+        add_new_model_results(
+            annotation_csv=str(tmp_path / "nope.csv"),
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=str(tmp_path / "nope.tif"),
+            new_model_column="m",
+        )
+
+    # Given: an annotation CSV that now exists, but still no sample tif
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+
+    # When: add_new_model_results runs
+    # Then: the next precondition fails fast, naming the tif
+    with pytest.raises(FileNotFoundError, match="tif"):
+        add_new_model_results(
+            annotation_csv=ann,
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=str(tmp_path / "nope.tif"),
+            new_model_column="m",
+        )
+
+
+def test_sample_tif_without_crs_raises_value_error(tmp_path):
+    # Given: a sample tif written with no CRS
+    ann = write_annotation_csv(tmp_path / "ann.csv", [("2024-10-14", C1)])
+    tif = write_sample_tif(tmp_path / "nocrs.tif", crs=None)
+
+    # When: add_new_model_results tries to read the raster CRS
+    # Then: it raises ValueError instead of counting in an undefined CRS
+    with pytest.raises(ValueError, match="CRS"):
+        add_new_model_results(
+            annotation_csv=ann,
+            output_csv=str(tmp_path / "out.csv"),
+            prediction_dir=str(tmp_path),
+            sample_tif=tif,
+            new_model_column="m",
+        )

--- a/tests/test_annotation_reference.py
+++ b/tests/test_annotation_reference.py
@@ -1,0 +1,251 @@
+"""Tests for displacement_tracker/evaluation/annotation_reference.py."""
+
+import numpy as np
+import pytest
+from rasterio.transform import from_origin
+from shapely.geometry import box
+
+from _helpers import CRS_UTM, CRS_WGS84, utm_to_lonlat, write_annotation_csv
+from displacement_tracker.evaluation.annotation_reference import (
+    ManualAnnotationReferenceSource,
+    _select_date,
+)
+
+# 0.01-degree grid anchored at (34.0 E, 32.0 N): cell (row r, col c) covers
+# lon [34.0 + 0.01c, 34.0 + 0.01(c+1)) and lat (32.0 - 0.01(r+1), 32.0 - 0.01r].
+GRID_TRANSFORM = from_origin(34.0, 32.0, 0.01, 0.01)
+GRID_SHAPE = (10, 10)
+
+
+# ==========================================================
+# Date selection
+# ==========================================================
+
+
+def test_multi_date_csv_without_date_raises_listing_available(tmp_path):
+    # Given: a CSV with annotations on 2024-10-14 and 2024-11-01
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.99,34.005,5\n", "2024-11-01,31.99,34.005,7\n"],
+    )
+
+    # When: the source is constructed without a date
+    # Then: it raises ValueError whose message lists both available dates
+    with pytest.raises(ValueError, match=r"2024-10-14.*2024-11-01"):
+        ManualAnnotationReferenceSource(csv)
+
+
+def test_single_date_csv_works_without_date(tmp_path):
+    # Given: a CSV whose rows all carry the same date, holding counts 5 and 4
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.965,34.025,4\n"],
+    )
+
+    # When: the source is constructed with date=None and rasterized
+    source = ManualAnnotationReferenceSource(csv)
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: no error is raised and both tiles are loaded (5 + 4 = 9)
+    assert counts.sum() == pytest.approx(9.0)
+
+
+def test_date_selection_accepts_dashed_and_compact_forms(tmp_path):
+    # Given: a two-date CSV (counts 5 on 2024-10-14, 7 on 2024-11-01)
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-11-01,31.995,34.005,7\n"],
+    )
+
+    # When: the source is built with date "2024-10-14" and with "20241014"
+    # Then: both forms select only the October rows (total count 5)
+    for date in ("2024-10-14", "20241014"):
+        source = ManualAnnotationReferenceSource(csv, date=date)
+        counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+        assert counts.sum() == pytest.approx(5.0)
+
+
+def test_unknown_date_raises_listing_available(tmp_path):
+    # Given: a CSV with only 2024-10-14 annotations
+    csv = write_annotation_csv(tmp_path / "ann.csv", ["2024-10-14,31.995,34.005,5\n"])
+
+    # When: the source is built for the absent date 2023-01-01
+    # Then: ValueError names the requested date and the available one
+    with pytest.raises(ValueError, match=r"2023-01-01.*2024-10-14"):
+        ManualAnnotationReferenceSource(csv, date="2023-01-01")
+
+
+def test_select_date_ignores_nan_dates_when_counting_ambiguity():
+    import pandas as pd
+
+    # Given: a frame with one real date plus a NaN date entry
+    df = pd.DataFrame({"date": ["2024-10-14", np.nan], "manual_tent_count": [1, 2]})
+
+    # When: _select_date runs with date=None
+    out = _select_date(df, None, "date", "fake.csv")
+
+    # Then: NaN does not count as a second date, so the frame passes through
+    #       with both rows intact
+    assert len(out) == 2
+
+
+def test_missing_csv_raises_file_not_found(tmp_path):
+    # Given: a path to a CSV that does not exist
+    missing = str(tmp_path / "nope.csv")
+
+    # When: the source is constructed on that path
+    # Then: FileNotFoundError is raised (not a pandas read error)
+    with pytest.raises(FileNotFoundError):
+        ManualAnnotationReferenceSource(missing)
+
+
+def test_missing_count_column_raises(tmp_path):
+    # Given: a CSV lacking the manual_tent_count column
+    csv = tmp_path / "ann.csv"
+    csv.write_text("date,latitude,longitude\n2024-10-14,31.99,34.005\n")
+
+    # When: the source is constructed
+    # Then: the column validation raises ValueError naming the column
+    with pytest.raises(ValueError, match="manual_tent_count"):
+        ManualAnnotationReferenceSource(str(csv))
+
+
+# ==========================================================
+# counts_on_grid
+# ==========================================================
+
+
+def test_counts_on_grid_additive_merge_and_cell_placement(tmp_path):
+    # Given: two tiles at (34.005, 31.995) with counts 5 and 7 — both in grid
+    #        cell (row 0, col 0) — and one tile at (34.025, 31.965) with count 4
+    #        in cell (row 3, col 2)
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        [
+            "2024-10-14,31.995,34.005,5\n",
+            "2024-10-14,31.995,34.005,7\n",
+            "2024-10-14,31.965,34.025,4\n",
+        ],
+    )
+    source = ManualAnnotationReferenceSource(csv)
+
+    # When: counts_on_grid rasterizes onto the 10x10 0.01-degree grid
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: cell (0,0) holds the SUM 12 (additive merge), cell (3,2) holds 4,
+    #       everything else is 0, and the dtype is float32
+    assert counts.dtype == np.float32
+    assert counts[0, 0] == pytest.approx(12.0)
+    assert counts[3, 2] == pytest.approx(4.0)
+    assert counts.sum() == pytest.approx(16.0)
+
+
+def test_counts_on_grid_reprojects_tiles_into_grid_crs(tmp_path):
+    # Given: a tile whose WGS84 centroid corresponds to UTM 36N (500000+50,
+    #        3474000+50) and a 100 m UTM grid anchored at (500000, 3474100)
+    lon, lat = utm_to_lonlat(500050.0, 3474050.0)
+    csv = write_annotation_csv(tmp_path / "ann.csv", [f"2024-10-14,{lat},{lon},9\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    utm_transform = from_origin(500000.0, 3474100.0, 100.0, 100.0)
+
+    # When: counts_on_grid runs with crs EPSG:32636
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM)
+
+    # Then: the tile's count 9 lands in cell (row 0, col 0) of the UTM grid
+    assert counts[0, 0] == pytest.approx(9.0)
+    assert counts.sum() == pytest.approx(9.0)
+
+
+def test_counts_on_grid_clip_geom_is_applied_in_grid_crs(tmp_path):
+    # Given: a tile whose WGS84 centroid reprojects to UTM 36N (500050,
+    #        3474050), the 3x3 100 m UTM grid anchored at (500000, 3474100),
+    #        and clip boxes expressed in the GRID CRS (as documented)
+    lon, lat = utm_to_lonlat(500050.0, 3474050.0)
+    csv = write_annotation_csv(tmp_path / "ann.csv", [f"2024-10-14,{lat},{lon},9\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    utm_transform = from_origin(500000.0, 3474100.0, 100.0, 100.0)
+
+    # When: counts_on_grid runs with crs EPSG:32636 and the clip box
+    #       box(500000, 3474000, 500100, 3474100), which contains the
+    #       REPROJECTED tile
+    containing = box(500000.0, 3474000.0, 500100.0, 3474100.0)
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM, containing)
+
+    # Then: the box keeps the tile — count 9 in cell (0, 0), since x 500050
+    #       falls in column 0's [500000, 500100) and y 3474050 in row 0's
+    #       (3474000, 3474100] — which requires reprojecting BEFORE clipping
+    #       (in WGS84 the tile sits near lon 34, nowhere near x=500000)
+    assert counts[0, 0] == pytest.approx(9.0)
+    assert counts.sum() == pytest.approx(9.0)
+
+    # When: the same call runs with box(500200, 3474000, 500300, 3474100),
+    #       which is disjoint from the reprojected tile
+    disjoint = box(500200.0, 3474000.0, 500300.0, 3474100.0)
+    counts = source.counts_on_grid((3, 3), utm_transform, CRS_UTM, disjoint)
+
+    # Then: nothing survives the clip and the grid is all zeros
+    assert counts.sum() == 0.0
+
+
+def test_counts_on_grid_clip_geom_excludes_outside_tiles(tmp_path):
+    # Given: tiles at (34.005, 31.995) count 5 and (34.025, 31.965) count 4,
+    #        and a clip box covering only the first tile
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.965,34.025,4\n"],
+    )
+    source = ManualAnnotationReferenceSource(csv)
+    clip = box(34.0, 31.98, 34.02, 32.0)
+
+    # When: counts_on_grid runs with that clip_geom
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84, clip)
+
+    # Then: only the first tile contributes; total is 5 and cell (3,2) is 0
+    assert counts[0, 0] == pytest.approx(5.0)
+    assert counts[3, 2] == pytest.approx(0.0)
+    assert counts.sum() == pytest.approx(5.0)
+
+
+def test_counts_on_grid_all_clipped_returns_zeros(tmp_path):
+    # Given: one tile and a clip geometry that contains no tiles
+    csv = write_annotation_csv(tmp_path / "ann.csv", ["2024-10-14,31.995,34.005,5\n"])
+    source = ManualAnnotationReferenceSource(csv)
+    clip = box(35.0, 30.0, 35.1, 30.1)
+
+    # When: counts_on_grid runs
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84, clip)
+
+    # Then: a float32 all-zero array of the grid shape is returned
+    assert counts.shape == GRID_SHAPE
+    assert counts.dtype == np.float32
+    assert counts.sum() == 0.0
+
+
+def test_nan_counts_are_dropped_not_rasterized(tmp_path):
+    # Given: two tiles in the same cell, one with count 5 and one with an
+    #        empty (NaN) count
+    csv = write_annotation_csv(
+        tmp_path / "ann.csv",
+        ["2024-10-14,31.995,34.005,5\n", "2024-10-14,31.995,34.005,\n"],
+    )
+
+    # When: the source loads and rasterizes them
+    source = ManualAnnotationReferenceSource(csv)
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: the NaN tile is dropped, leaving 5 in the cell (not NaN, not 5+0)
+    assert counts[0, 0] == pytest.approx(5.0)
+    assert np.isfinite(counts).all()
+
+
+def test_custom_count_column(tmp_path):
+    # Given: a CSV whose count column is named other_count (value 11)
+    csv = tmp_path / "ann.csv"
+    csv.write_text("date,latitude,longitude,other_count\n2024-10-14,31.995,34.005,11\n")
+
+    # When: the source is built with count_column="other_count" and rasterized
+    source = ManualAnnotationReferenceSource(str(csv), count_column="other_count")
+    counts = source.counts_on_grid(GRID_SHAPE, GRID_TRANSFORM, CRS_WGS84)
+
+    # Then: that column drives the rasterized totals
+    assert counts[0, 0] == pytest.approx(11.0)

--- a/tests/test_config_flows.py
+++ b/tests/test_config_flows.py
@@ -1,0 +1,262 @@
+"""Tests for displacement_tracker.util.config: dotted-path helpers, deep
+merging, and sectioned shared/per-flow config resolution."""
+
+import click
+import pytest
+
+from displacement_tracker.util.config import (
+    deep_get,
+    deep_merge,
+    deep_set,
+    is_sectioned_config,
+    load_flow_config,
+    resolve_flow_config,
+)
+
+
+def test_deep_get_returns_nested_value():
+    # Given: a three-level nested dict with value 7 at a.b.c
+    cfg = {"a": {"b": {"c": 7}}}
+
+    # When: deep_get is asked for the dotted path "a.b.c" and for "a.b"
+    leaf = deep_get(cfg, "a.b.c")
+    branch = deep_get(cfg, "a.b")
+
+    # Then: it returns 7, and a one-level path returns the intermediate dict
+    assert leaf == 7
+    assert branch == {"c": 7}
+
+
+def test_deep_get_missing_or_non_dict_returns_default():
+    # Given: a dict where "a.b" is a scalar and "x" does not exist
+    cfg = {"a": {"b": 5}, "lst": [1, 2]}
+
+    # When: deep_get traverses a missing key or descends through a non-dict
+    absent_root = deep_get(cfg, "x", default="dflt")
+    through_scalar = deep_get(cfg, "a.b.c", default=-1)  # 5 is not a dict
+    into_list = deep_get(cfg, "lst.0")  # lists are not traversed
+    absent_leaf = deep_get(cfg, "a.missing", default=0)
+
+    # Then: the supplied default is returned instead of raising
+    assert absent_root == "dflt"
+    assert through_scalar == -1
+    assert into_list is None
+    assert absent_leaf == 0
+
+
+def test_deep_set_creates_intermediate_dicts():
+    # Given: an empty config dict
+    cfg = {}
+
+    # When: deep_set writes value 1 at dotted path "a.b.c"
+    deep_set(cfg, "a.b.c", 1)
+
+    # Then: all intermediate dicts are created and the leaf holds 1
+    assert cfg == {"a": {"b": {"c": 1}}}
+
+
+def test_deep_set_replaces_non_dict_intermediates():
+    # Given: a config where "a" is a scalar (5)
+    cfg = {"a": 5, "keep": True}
+
+    # When: deep_set writes at "a.b", which needs "a" to be a dict
+    deep_set(cfg, "a.b", 2)
+
+    # Then: the scalar is replaced by a fresh dict holding the leaf
+    assert cfg == {"a": {"b": 2}, "keep": True}
+
+
+def test_deep_merge_nested_extra_wins_and_mutates_base():
+    # Given: base and extra sharing the nested key m.x with different values
+    base = {"m": {"x": 1, "y": 2}, "only_base": "b"}
+    extra = {"m": {"x": 10, "z": 3}, "only_extra": "e"}
+
+    # When: deep_merge(base, extra) runs
+    result = deep_merge(base, extra)
+
+    # Then: extra's m.x wins, base-only keys survive at every level, and the
+    #       returned object is the mutated base itself
+    assert result is base
+    assert base == {
+        "m": {"x": 10, "y": 2, "z": 3},
+        "only_base": "b",
+        "only_extra": "e",
+    }
+
+
+def test_deep_merge_type_conflicts_extra_always_wins():
+    # Given: base has a dict where extra has a scalar, and vice versa
+    base = {"a": {"nested": 1}, "b": 2}
+    extra = {"a": "scalar", "b": {"now": "dict"}}
+
+    # When: deep_merge runs
+    deep_merge(base, extra)
+
+    # Then: extra's value replaces base's wholesale in both directions
+    assert base == {"a": "scalar", "b": {"now": "dict"}}
+
+
+def test_is_sectioned_config_detection():
+    # Given: dicts with and without shared/train/predict/tune top-level keys,
+    #        plus a value that is not a dict at all
+    shared_marked = {"shared": {}}
+    tune_marked = {"tune": {"a": 1}}
+    flat = {"geotiff_dir": "/x", "merge": {}}
+
+    # When: is_sectioned_config inspects each of them
+    shared_result = is_sectioned_config(shared_marked)
+    tune_result = is_sectioned_config(tune_marked)
+    flat_result = is_sectioned_config(flat)
+    non_dict_result = is_sectioned_config("not a dict")
+
+    # Then: any section key marks it sectioned; flat configs and non-dicts
+    #       are not sectioned
+    assert shared_result is True
+    assert tune_result is True
+    assert flat_result is False
+    assert non_dict_result is False
+
+
+def test_resolve_flat_config_passes_through_unchanged():
+    # Given: a legacy flat config (no section keys)
+    cfg = {"geotiff_dir": "/data", "merge": {"agreement": 2}}
+
+    # When: resolve_flow_config is called with a flow, and with None
+    with_flow = resolve_flow_config(cfg, "predict")
+    without_flow = resolve_flow_config(cfg, None)
+
+    # Then: the very same object is returned untouched
+    assert with_flow is cfg
+    assert without_flow is cfg
+    assert cfg == {"geotiff_dir": "/data", "merge": {"agreement": 2}}
+
+
+def test_resolve_sectioned_flow_wins_over_shared():
+    # Given: shared defines processing.core=100 and boundaries; the predict
+    #        section overrides processing.core=50 and adds a model key
+    cfg = {
+        "shared": {
+            "boundaries": "/b.shp",
+            "processing": {"core": 100, "margin": 10},
+        },
+        "predict": {"model": "/m.pth", "processing": {"core": 50}},
+        "train": {"epochs": 3},
+    }
+
+    # When: resolving flow "predict"
+    resolved = resolve_flow_config(cfg, "predict")
+
+    # Then: the flat result deep-merges predict over shared — core=50,
+    #       shared-only keys (margin, boundaries) survive, and no section
+    #       names appear in the output
+    assert resolved == {
+        "boundaries": "/b.shp",
+        "processing": {"core": 50, "margin": 10},
+        "model": "/m.pth",
+    }
+    assert "shared" not in resolved and "train" not in resolved
+
+
+def test_resolve_sectioned_returns_deep_copies():
+    # Given: a sectioned config with a nested dict in shared
+    cfg = {
+        "shared": {"processing": {"core": 100}},
+        "tune": {"tuning": {"metric": "rms"}},
+    }
+
+    # When: the tune flow is resolved and the result is mutated afterwards
+    resolved = resolve_flow_config(cfg, "tune")
+    resolved["processing"]["core"] = -1
+    resolved["tuning"]["metric"] = "mae"
+
+    # Then: the original shared/flow sections are unaffected (deep copies)
+    assert cfg["shared"]["processing"]["core"] == 100
+    assert cfg["tune"]["tuning"]["metric"] == "rms"
+
+
+def test_resolve_rejects_mixed_sectioned_and_stray_keys():
+    # Given: a half-migrated config with a "shared" section plus stray
+    #        top-level keys "zeta" and "alpha"
+    cfg = {"shared": {}, "predict": {}, "zeta": 1, "alpha": 2}
+
+    # When: resolving any flow
+    # Then: click.UsageError names the stray keys in sorted order
+    with pytest.raises(click.UsageError, match="alpha, zeta"):
+        resolve_flow_config(cfg, "predict")
+
+
+def test_resolve_sectioned_without_flow_raises():
+    # Given: a valid sectioned config
+    cfg = {"shared": {}, "predict": {"a": 1}}
+
+    # When: resolve_flow_config is called with flow=None
+    # Then: click.UsageError asks for --flow
+    with pytest.raises(click.UsageError, match="--flow"):
+        resolve_flow_config(cfg, None)
+
+
+def test_resolve_unknown_flow_raises():
+    # Given: a sectioned config and a flow name outside FLOWS
+    cfg = {"shared": {}, "predict": {"a": 1}}
+
+    # When: resolving flow "evaluate"
+    # Then: click.UsageError reports the unknown flow name
+    with pytest.raises(click.UsageError, match="evaluate"):
+        resolve_flow_config(cfg, "evaluate")
+
+
+def test_resolve_missing_flow_section_raises():
+    # Given: a sectioned config that has predict but no train section
+    cfg = {"shared": {"a": 1}, "predict": {"b": 2}}
+
+    # When: resolving flow "train" (a valid flow name)
+    # Then: click.UsageError reports the missing 'train' section
+    with pytest.raises(click.UsageError, match="no 'train' section"):
+        resolve_flow_config(cfg, "train")
+
+
+def test_resolve_handles_null_shared_and_null_flow_sections():
+    # Given: YAML-style empty sections parse to None — one config with
+    #        shared: null, another with an empty tune: section
+    null_shared = {"shared": None, "tune": {"a": 1}}
+    null_flow = {"shared": {"b": 2}, "tune": None}
+
+    # When: resolving the tune flow in each
+    from_null_shared = resolve_flow_config(null_shared, "tune")
+    from_null_flow = resolve_flow_config(null_flow, "tune")
+
+    # Then: null shared resolves to just the flow section, and a null flow
+    #       section resolves to just shared (no crash on None)
+    assert from_null_shared == {"a": 1}
+    assert from_null_flow == {"b": 2}
+
+
+def test_load_flow_config_reads_yaml_substitutes_env_and_resolves(
+    tmp_path, monkeypatch
+):
+    # Given: a real sectioned YAML file referencing ${TENTNET_TEST_DATA} in
+    #        shared, with a train section overriding batch_size, and the env
+    #        var set
+    monkeypatch.setenv("TENTNET_TEST_DATA", "/mnt/data")
+    cfg_file = tmp_path / "cfg.yaml"
+    cfg_file.write_text(
+        "shared:\n"
+        "  geotiff_dir: ${TENTNET_TEST_DATA}/tifs\n"
+        "  training:\n"
+        "    batch_size: 8\n"
+        "train:\n"
+        "  training:\n"
+        "    batch_size: 32\n"
+        "predict:\n"
+        "  model: m.pth\n"
+    )
+
+    # When: load_flow_config loads it for flow "train"
+    resolved = load_flow_config(str(cfg_file), "train")
+
+    # Then: the env var is substituted into the value and the train section
+    #       is deep-merged over shared (train's batch_size wins)
+    assert resolved == {
+        "geotiff_dir": "/mnt/data/tifs",
+        "training": {"batch_size": 32},
+    }

--- a/tests/test_evaluation_common.py
+++ b/tests/test_evaluation_common.py
@@ -1,0 +1,490 @@
+"""Tests for displacement_tracker/evaluation/scripts/common.py and the
+config-resolution/preflight logic of displacement_tracker/evaluation/run_all_analyses.py.
+"""
+
+import json
+import math
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")  # run_all_analyses imports plot modules
+
+import click
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from click.testing import CliRunner
+from shapely.geometry import Point, box
+
+from displacement_tracker.evaluation.run_all_analyses import cli, load_config, require
+from displacement_tracker.evaluation.scripts.common import (
+    build_hex_grid,
+    choose_utm_crs_from_gdf,
+    finite_xy,
+    group_error_summary,
+    hex_error_aggregation,
+    load_annotation_points,
+    load_annotations,
+    load_layer,
+    make_hexagon,
+    mean_error_ci,
+    read_annotations,
+)
+
+# ==========================================================
+# Annotation loading
+# ==========================================================
+
+
+def test_read_annotations_missing_columns_listed_sorted(tmp_path):
+    # Given: a CSV with only columns a and b
+    csv = tmp_path / "ann.csv"
+    csv.write_text("a,b\n1,2\n")
+
+    # When: read_annotations requires columns b, z, y and a (z and y absent)
+    # Then: it raises ValueError listing the missing columns in sorted order
+    #       ['y', 'z'], regardless of the order they were requested in
+    with pytest.raises(ValueError, match=r"\['y', 'z'\]"):
+        read_annotations(str(csv), required_columns=("b", "z", "y", "a"))
+
+
+def test_load_annotations_tile_error_is_model_minus_manual(tmp_path):
+    # Given: a CSV with manual counts [10, 4] and model counts [7, 9]
+    csv = tmp_path / "ann.csv"
+    csv.write_text("manual,model\n10,7\n4,9\n")
+
+    # When: load_annotations computes tile_error
+    df = load_annotations(str(csv), manual_column="manual", model_column="model")
+
+    # Then: tile_error is model - manual, i.e. [-3, 5]
+    assert df["tile_error"].tolist() == [-3, 5]
+
+
+def test_load_annotation_points_requires_lat_lon_and_builds_wgs84_points(tmp_path):
+    # Given: a CSV with lat/lon and count columns
+    csv = tmp_path / "ann.csv"
+    csv.write_text("latitude,longitude,manual,model\n31.5,34.25,3,8\n")
+
+    # When: load_annotation_points loads it
+    gdf = load_annotation_points(str(csv), manual_column="manual", model_column="model")
+
+    # Then: the result is EPSG:4326 points at (lon, lat) with tile_error attached
+    assert gdf.crs.to_epsg() == 4326
+    assert gdf.geometry.iloc[0].x == pytest.approx(34.25)
+    assert gdf.geometry.iloc[0].y == pytest.approx(31.5)
+    assert gdf["tile_error"].iloc[0] == 5
+
+
+def test_load_annotation_points_missing_latitude_raises(tmp_path):
+    # Given: a CSV that has longitude but no latitude column
+    csv = tmp_path / "ann.csv"
+    csv.write_text("longitude,manual,model\n34.25,3,8\n")
+
+    # When: load_annotation_points is called
+    # Then: the implicit latitude requirement fails with ValueError
+    with pytest.raises(ValueError, match="latitude"):
+        load_annotation_points(str(csv), manual_column="manual", model_column="model")
+
+
+def test_load_layer_reprojects_to_target_crs(tmp_path):
+    # Given: a GeoJSON point layer at lon 34.3 in EPSG:4326
+    path = tmp_path / "layer.geojson"
+    gpd.GeoDataFrame(
+        {"name": ["p"]}, geometry=[Point(34.3, 31.4)], crs="EPSG:4326"
+    ).to_file(path, driver="GeoJSON")
+
+    # When: load_layer is asked for EPSG:3857
+    out = load_layer(str(path), "EPSG:3857", required_columns=("name",))
+
+    # Then: the returned layer is in 3857 with x = R * radians(lon) (spherical
+    #       Mercator definition, R = 6378137 m)
+    assert out.crs.to_epsg() == 3857
+    assert out.geometry.iloc[0].x == pytest.approx(6378137 * math.radians(34.3))
+
+
+def test_load_layer_missing_required_column_raises(tmp_path):
+    # Given: a vector layer whose only attribute column is "name"
+    path = tmp_path / "layer.geojson"
+    gpd.GeoDataFrame({"name": ["p"]}, geometry=[Point(0, 0)], crs="EPSG:4326").to_file(
+        path, driver="GeoJSON"
+    )
+
+    # When: load_layer requires a column "kind" that is absent
+    # Then: it raises ValueError mentioning the missing column
+    with pytest.raises(ValueError, match="kind"):
+        load_layer(str(path), None, required_columns=("name", "kind"))
+
+
+def test_finite_xy_drops_pairs_with_any_nonfinite_member():
+    # Given: x = [1, nan, 3, inf, 5] and y = [10, 20, nan, 40, 50]
+    xs = [1, np.nan, 3, np.inf, 5]
+    ys = [10, 20, np.nan, 40, 50]
+
+    # When: finite_xy filters the pair
+    x, y = finite_xy(xs, ys)
+
+    # Then: only positions where BOTH are finite survive: (1,10) and (5,50)
+    assert x.tolist() == [1.0, 5.0]
+    assert y.tolist() == [10.0, 50.0]
+
+
+# ==========================================================
+# Error summaries
+# ==========================================================
+
+
+def test_mean_error_ci_hand_computed_four_values():
+    # Given: errors [1, 2, 3, 6] (mean 3; sample var = 14/3; std = sqrt(14/3))
+    errors = [1, 2, 3, 6]
+
+    # When: mean_error_ci runs with z = 1.96
+    stats = mean_error_ci(errors)
+
+    # Then: margin = 1.96 * sqrt(14/3) / 2 and the CI is mean -/+ margin
+    std = math.sqrt(14 / 3)
+    margin = 1.96 * std / 2
+    assert stats["mean_tile_error"] == pytest.approx(3.0)
+    assert stats["std_tile_error"] == pytest.approx(std, rel=1e-12)
+    assert stats["ci_lower"] == pytest.approx(3.0 - margin, rel=1e-12)
+    assert stats["ci_upper"] == pytest.approx(3.0 + margin, rel=1e-12)
+    assert stats["num_tiles"] == 4
+
+
+def test_mean_error_ci_single_value_has_zero_std_and_degenerate_ci():
+    # Given: a single error value 4.5
+    errors = [4.5]
+
+    # When: mean_error_ci runs
+    stats = mean_error_ci(errors)
+
+    # Then: std is 0.0 and both CI bounds equal the mean
+    assert stats == {
+        "mean_tile_error": 4.5,
+        "std_tile_error": 0.0,
+        "ci_lower": 4.5,
+        "ci_upper": 4.5,
+        "num_tiles": 1,
+    }
+
+
+def test_mean_error_ci_ignores_nonfinite_and_none_when_empty():
+    # Given: errors [1, nan, 3] (finite subset has mean 2, std sqrt(2), n=2)
+    errors = [1, np.nan, 3]
+
+    # When: mean_error_ci runs
+    stats = mean_error_ci(errors)
+
+    # Then: non-finite values are excluded so margin = 1.96 * sqrt(2)/sqrt(2) = 1.96
+    assert stats["num_tiles"] == 2
+    assert stats["mean_tile_error"] == pytest.approx(2.0)
+    assert stats["ci_lower"] == pytest.approx(2.0 - 1.96, rel=1e-12)
+    assert stats["ci_upper"] == pytest.approx(2.0 + 1.96, rel=1e-12)
+
+    # When: mean_error_ci runs on inputs with no finite value at all
+    # Then: there is nothing to summarize, so the result is None
+    assert mean_error_ci([np.nan, np.inf]) is None
+    assert mean_error_ci([]) is None
+
+
+def test_group_error_summary_per_group_stats_and_skips():
+    # Given: groups A -> errors [1, 3], B -> [5], C -> [nan], and one row with
+    #        a NaN group key
+    frame = pd.DataFrame(
+        {
+            "group": ["A", "A", "B", "C", np.nan],
+            "tile_error": [1.0, 3.0, 5.0, np.nan, 99.0],
+        }
+    )
+
+    # When: group_error_summary aggregates tile_error by group
+    out = group_error_summary(frame, "group")
+
+    # Then: A has mean 2, std sqrt(2), CI 2 -/+ 1.96, n=2; B has mean 5 with a
+    #       zero-width CI; C and the NaN-key row produce no rows at all
+    assert out["group"].tolist() == ["A", "B"]
+    a = out[out["group"] == "A"].iloc[0]
+    assert a["mean_tile_error"] == pytest.approx(2.0)
+    assert a["std_tile_error"] == pytest.approx(math.sqrt(2), rel=1e-12)
+    assert a["ci_lower"] == pytest.approx(2.0 - 1.96, rel=1e-12)
+    assert a["num_tiles"] == 2
+    b = out[out["group"] == "B"].iloc[0]
+    assert b["mean_tile_error"] == pytest.approx(5.0)
+    assert b["ci_lower"] == pytest.approx(5.0)
+    assert b["ci_upper"] == pytest.approx(5.0)
+
+
+# ==========================================================
+# Hex grid
+# ==========================================================
+
+
+def test_choose_utm_crs_northern_and_southern_hemispheres():
+    # Given: a point at lon 34.3 / lat 31.4 (zone int(214.3/6)+1 = 36, north)
+    #        and one at lon -58.4 / lat -34.6 (zone int(121.6/6)+1 = 21, south)
+    north = gpd.GeoDataFrame(geometry=[Point(34.3, 31.4)], crs="EPSG:4326")
+    south = gpd.GeoDataFrame(geometry=[Point(-58.4, -34.6)], crs="EPSG:4326")
+
+    # When: choose_utm_crs_from_gdf picks a UTM CRS for each
+    north_crs = choose_utm_crs_from_gdf(north)
+    south_crs = choose_utm_crs_from_gdf(south)
+
+    # Then: they resolve to EPSG:32636 and EPSG:32721 respectively
+    assert north_crs.to_epsg() == 32636
+    assert south_crs.to_epsg() == 32721
+
+
+def test_choose_utm_crs_requires_a_crs():
+    # Given: a layer with no CRS set
+    gdf = gpd.GeoDataFrame(geometry=[Point(0, 0)])
+
+    # When: choose_utm_crs_from_gdf runs
+    # Then: it refuses with ValueError instead of guessing
+    with pytest.raises(ValueError, match="no CRS"):
+        choose_utm_crs_from_gdf(gdf)
+
+
+def test_make_hexagon_geometry():
+    # Given: side length a=2 centered at (10, 5)
+    center_x, center_y, side = 10.0, 5.0, 2.0
+
+    # When: make_hexagon builds the polygon
+    hexagon = make_hexagon(center_x, center_y, side)
+
+    # Then: area is 3*sqrt(3)/2 * a^2 = 6*sqrt(3) and bounds span
+    #       [center_x - a, center_x + a] x [center_y - a*sqrt(3)/2, ...]
+    assert hexagon.area == pytest.approx(6 * math.sqrt(3), rel=1e-12)
+    minx, miny, maxx, maxy = hexagon.bounds
+    assert (minx, maxx) == pytest.approx((8.0, 12.0))
+    assert miny == pytest.approx(5 - math.sqrt(3), rel=1e-12)
+    assert maxy == pytest.approx(5 + math.sqrt(3), rel=1e-12)
+
+
+def test_build_hex_grid_tiles_the_bounds_without_gaps_or_overlaps():
+    # Given: bounds (0, 0, 20, 20), side length a=5, and four interior sample
+    #        points chosen to sit off any hex edge
+    bounds = (0.0, 0.0, 20.0, 20.0)
+    samples = [Point(1.1, 2.3), Point(9.7, 4.4), Point(15.2, 18.9), Point(19.3, 0.6)]
+
+    # When: build_hex_grid lays out the flat-topped grid
+    hexes = build_hex_grid(bounds, 5.0)
+
+    # Then: every sample point is covered by exactly one hexagon — no gaps, no
+    #       double coverage
+    for sample in samples:
+        covering = sum(1 for h in hexes if h.contains(sample))
+        assert covering == 1, f"{sample.wkt} covered by {covering} hexes"
+
+
+def test_hex_error_aggregation_groups_points_and_computes_stats(tmp_path):
+    # Given: a lon/lat boundary box around (34.30, 31.40) (UTM zone 36N), two
+    #        annotated tiles at the exact same location with errors 1 and 3,
+    #        and a third tile ~1.66 km north with error 7; hex_size_m=1000 so
+    #        the hex circumradius is 500 m (max in-hex distance 1000 m)
+    boundary_path = tmp_path / "boundary.geojson"
+    gpd.GeoDataFrame(
+        geometry=[box(34.28, 31.38, 34.32, 31.42)], crs="EPSG:4326"
+    ).to_file(boundary_path, driver="GeoJSON")
+
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0, 3.0, 7.0]},
+        geometry=[Point(34.30, 31.40), Point(34.30, 31.40), Point(34.30, 31.415)],
+        crs="EPSG:4326",
+    )
+
+    # When: hex_error_aggregation aggregates tile_error onto the hex grid
+    hex_gdf, points_with_hex, boundary_proj = hex_error_aggregation(
+        points, str(boundary_path), hex_size_m=1000.0
+    )
+
+    # Then: the co-located pair shares one hex (n=2, mean 2, std sqrt(2)), the
+    #       far tile sits alone in a DIFFERENT hex (n=1, mean 7, std NaN), and
+    #       hexes without points carry n_tiles=0 with NaN mean
+    assert boundary_proj.crs.to_epsg() == 32636
+    assert len(points_with_hex) == 3
+
+    pair_hex_ids = points_with_hex.loc[points_with_hex["tile_error"] < 5, "hex_id"]
+    lone_hex_id = points_with_hex.loc[points_with_hex["tile_error"] == 7.0, "hex_id"]
+    assert pair_hex_ids.nunique() == 1
+    pair_hex = pair_hex_ids.iloc[0]
+    lone_hex = lone_hex_id.iloc[0]
+    assert pair_hex != lone_hex  # 1.66 km apart > 1 km max in-hex distance
+
+    pair_row = hex_gdf.set_index("hex_id").loc[pair_hex]
+    assert pair_row["n_tiles"] == 2
+    assert pair_row["mean_err"] == pytest.approx(2.0)
+    assert pair_row["std_err"] == pytest.approx(math.sqrt(2), rel=1e-12)
+
+    lone_row = hex_gdf.set_index("hex_id").loc[lone_hex]
+    assert lone_row["n_tiles"] == 1
+    assert lone_row["mean_err"] == pytest.approx(7.0)
+    assert pd.isna(lone_row["std_err"])
+
+    empty = hex_gdf[~hex_gdf["hex_id"].isin([pair_hex, lone_hex])]
+    assert not empty.empty
+    assert (empty["n_tiles"] == 0).all()
+    assert empty["mean_err"].isna().all()
+
+
+def test_hex_error_aggregation_hex_geometry_matches_hex_size(tmp_path):
+    # Given: a small UTM-zone-36N boundary and hex_size_m=1000, which the
+    #        aggregation must convert to a hexagon side (circumradius) of
+    #        a = hex_size_m / 2 = 500 m — a side of 1000 m instead would
+    #        quadruple each hex's area and silently coarsen the spatial
+    #        resolution of the error maps
+    boundary_path = tmp_path / "boundary.geojson"
+    gpd.GeoDataFrame(
+        geometry=[box(34.28, 31.38, 34.32, 31.42)], crs="EPSG:4326"
+    ).to_file(boundary_path, driver="GeoJSON")
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0]}, geometry=[Point(34.30, 31.40)], crs="EPSG:4326"
+    )
+
+    # When: hex_error_aggregation builds its hex grid
+    hex_gdf, _, _ = hex_error_aggregation(points, str(boundary_path), hex_size_m=1000.0)
+
+    # Then: every returned hex has area 3*sqrt(3)/2 * 500^2, and its x-extent
+    #       is exactly 1000.0 m (make_hexagon places vertices at 0 and 180
+    #       degrees, so the corner-to-corner diameter 2a runs along x while
+    #       the y-extent is only sqrt(3)*a)
+    expected_area = 3 * math.sqrt(3) / 2 * 500.0**2
+    assert hex_gdf.geometry.area.to_numpy() == pytest.approx(expected_area, rel=1e-9)
+    minx, miny, maxx, maxy = hex_gdf.geometry.iloc[0].bounds
+    assert maxx - minx == pytest.approx(1000.0, abs=1e-6)
+    assert maxy - miny == pytest.approx(math.sqrt(3) * 500.0, abs=1e-6)
+
+
+def test_hex_error_aggregation_empty_boundary_raises(tmp_path):
+    # Given: a boundary layer file containing zero features
+    boundary_path = tmp_path / "empty.geojson"
+    gpd.GeoDataFrame(geometry=[], crs="EPSG:4326").to_file(
+        boundary_path, driver="GeoJSON"
+    )
+    points = gpd.GeoDataFrame(
+        {"tile_error": [1.0]}, geometry=[Point(34.3, 31.4)], crs="EPSG:4326"
+    )
+
+    # When: hex_error_aggregation runs
+    # Then: it raises ValueError instead of building a grid over nothing
+    with pytest.raises(ValueError, match="empty"):
+        hex_error_aggregation(points, str(boundary_path), hex_size_m=1000.0)
+
+
+# ==========================================================
+# run_all_analyses config resolution and preflight
+# ==========================================================
+
+
+def test_load_config_resolves_relative_paths_against_config_dir(tmp_path):
+    # Given: a config file in tmp/cfgdir with a relative annotation_csv, an
+    #        absolute boundary_shp, a null prediction_dir and a non-path key
+    cfg_dir = tmp_path / "cfgdir"
+    cfg_dir.mkdir()
+    cfg_file = cfg_dir / "analysis.json"
+    absolute_boundary = str(tmp_path / "elsewhere" / "bounds.shp")
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "data/ann.csv",
+                "boundary_shp": absolute_boundary,
+                "prediction_dir": None,
+                "model_column": "model_tent_count",
+            }
+        )
+    )
+
+    # When: load_config loads it
+    cfg = load_config(cfg_file)
+
+    # Then: the relative path resolves against cfgdir (not the CWD), the
+    #       absolute path is preserved, null stays None and non-path keys
+    #       are untouched
+    assert cfg["annotation_csv"] == str((cfg_dir / "data" / "ann.csv").resolve())
+    assert cfg["boundary_shp"] == absolute_boundary
+    assert cfg["prediction_dir"] is None
+    assert cfg["model_column"] == "model_tent_count"
+
+
+def test_require_rejects_missing_and_falsy_values():
+    # Given: a config where key "a" is present, "b" is empty and "c" is absent
+    cfg = {"a": "value", "b": ""}
+
+    # When: require is called for the present key "a"
+    value = require(cfg, "a")
+
+    # Then: its value is returned
+    assert value == "value"
+
+    # When: require is called for the empty "b" and for the absent "c"
+    # Then: both raise ClickException naming the offending key
+    with pytest.raises(click.ClickException, match="b"):
+        require(cfg, "b")
+    with pytest.raises(click.ClickException, match="c"):
+        require(cfg, "c")
+
+
+def test_cli_preflight_lists_exactly_the_missing_inputs(tmp_path):
+    # Given: a config whose annotation_csv exists but whose four spatial
+    #        layers point at nonexistent relative paths
+    ann = tmp_path / "ann.csv"
+    ann.write_text("date,latitude,longitude,manual_tent_count,model_tent_count\n")
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "ann.csv",
+                "output_dir": "results",
+                "boundary_shp": "missing/bounds.shp",
+                "agriculture_geojson": "missing/agri.json",
+                "h3_geojson": "missing/h3.json",
+                "destruction_geojson": "missing/destr.json",
+            }
+        )
+    )
+
+    # When: the run-evaluation CLI runs its preflight check
+    result = CliRunner().invoke(cli, ["--config", str(cfg_file)])
+
+    # Then: it fails listing each missing resolved path, does not list the
+    #       existing annotation CSV, and does not create output_dir
+    assert result.exit_code != 0
+    for rel in ("bounds.shp", "agri.json", "h3.json", "destr.json"):
+        assert str((tmp_path / "missing" / rel).resolve()) in result.output
+    assert str(ann.resolve()) not in result.output
+    assert not (tmp_path / "results").exists()
+
+
+def test_cli_partial_new_model_config_fails_naming_missing_key(tmp_path):
+    # Given: a config whose preflight input files all exist as tiny dummies
+    #        and which sets prediction_dir but omits sample_tif and
+    #        new_model_column — a partially specified new-model run; this
+    #        exercises the fail-fast misconfiguration guard, not click
+    #        argument plumbing
+    ann = tmp_path / "ann.csv"
+    ann.write_text("date,latitude,longitude,manual_tent_count,model_tent_count\n")
+    for dummy in ("bounds.shp", "agri.json", "h3.json", "destr.json"):
+        (tmp_path / dummy).write_text("dummy")
+    (tmp_path / "preds").mkdir()
+    cfg_file = tmp_path / "config.json"
+    cfg_file.write_text(
+        json.dumps(
+            {
+                "annotation_csv": "ann.csv",
+                "output_dir": "results",
+                "boundary_shp": "bounds.shp",
+                "agriculture_geojson": "agri.json",
+                "h3_geojson": "h3.json",
+                "destruction_geojson": "destr.json",
+                "prediction_dir": "preds",
+            }
+        )
+    )
+
+    # When: the run-evaluation CLI resolves the config
+    result = CliRunner().invoke(cli, ["--config", str(cfg_file)])
+
+    # Then: because ANY new-model key being set marks the run as a new-model
+    #       run, it aborts with "Missing required config key" naming
+    #       sample_tif instead of silently falling back to evaluating the
+    #       old model_column
+    assert result.exit_code != 0
+    assert "Missing required config key: sample_tif" in result.output

--- a/tests/test_pipeline_runner.py
+++ b/tests/test_pipeline_runner.py
@@ -1,0 +1,379 @@
+"""Tests for the pipeline specs (displacement_tracker.pipelines.spec) and
+the run preparation logic (displacement_tracker.pipelines.runner).
+
+prepare_run's config layering contract:
+    extra_defaults < resolved base config < overrides < forced_values,
+with artifact_paths forced into the run directory last.
+"""
+
+import os
+import sys
+
+import pytest
+import yaml
+
+from displacement_tracker.pipelines.runner import (
+    default_run_root,
+    prepare_run,
+    stage_argv,
+)
+from displacement_tracker.pipelines.spec import PREDICT, TRAIN, TUNE, Pipeline
+
+
+def _make_pipeline(**kwargs) -> Pipeline:
+    defaults = dict(
+        key="predict",
+        label="Test pipeline",
+        base_config="config.yaml",
+        stages=(),
+        params=(),
+    )
+    defaults.update(kwargs)
+    return Pipeline(**defaults)
+
+
+def test_subfolders_take_first_path_component_plus_logs():
+    # Given: artifact paths "manifests", "dataset/balanced.parquet",
+    #        "dataset/other.bin" and "deep/a/b"
+    p = _make_pipeline(
+        artifact_paths={
+            "a": "manifests",
+            "b": "dataset/balanced.parquet",
+            "c": "dataset/other.bin",
+            "d": "deep/a/b",
+        }
+    )
+
+    # When: Pipeline.subfolders derives the fixed run-dir subfolders
+    subfolders = p.subfolders
+
+    # Then: each relative path contributes only its first component,
+    #       duplicates collapse, "logs" is always included, sorted output
+    assert subfolders == ["dataset", "deep", "logs", "manifests"]
+
+
+def test_prepare_run_layering_defaults_base_overrides_forced(tmp_path):
+    # Given: a pipeline with extra_defaults sec={a:1,b:2,d:4}, forced
+    #        sec.b=99, and a flat base config sec={b:5,c:7} plus other=keep
+    pipeline = _make_pipeline(
+        extra_defaults={"sec": {"a": 1, "b": 2, "d": 4}},
+        forced_values={"sec.b": 99},
+    )
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"sec": {"b": 5, "c": 7}, "other": "keep"}))
+
+    # When: prepare_run applies overrides {sec.c:8, sec.d:40, new.deep.key:True}
+    ctx = prepare_run(
+        pipeline,
+        base,
+        overrides={"sec.c": 8, "sec.d": 40, "new.deep.key": True},
+        run_name="run1",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: each key lands at its layer — a=1 (default only), b=99 (forced
+    #       beats base's 5), c=8 (override beats base's 7), d=40 (override
+    #       beats default's 4), other survives, and the dotted override
+    #       created the nested "new" structure
+    assert ctx.config["sec"] == {"a": 1, "b": 99, "c": 8, "d": 40}
+    assert ctx.config["other"] == "keep"
+    assert ctx.config["new"] == {"deep": {"key": True}}
+    # The written config.yaml is the same resolved config, read back for real.
+    with open(ctx.config_path) as f:
+        assert yaml.safe_load(f) == ctx.config
+
+
+def test_prepare_run_tune_invariants_survive_poisoned_config_and_overrides(tmp_path):
+    # Given: a sectioned base config whose shared and tune sections poison
+    #        the merge thresholds (min_adj_peak 0.9, adjustment_factor 5.0,
+    #        thresholds_config set)
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "shared": {"merge": {"min_adj_peak": 0.9}},
+                "predict": {"model": "m.pth"},
+                "tune": {
+                    "merge": {
+                        "adjustment_factor": 5.0,
+                        "thresholds_config": "/poison.yaml",
+                        "agreement": 2,
+                    },
+                    "tuning": {"metric": "mae"},
+                },
+            }
+        )
+    )
+
+    # When: prepare_run builds a TUNE run with overrides poisoning the same
+    #       thresholds again
+    ctx = prepare_run(
+        TUNE,
+        base,
+        overrides={
+            "merge.min_adj_peak": 0.5,
+            "merge.adjustment_factor": 9.0,
+            "merge.thresholds_config": "/still_poison.yaml",
+            "merge.agreement": 4,
+        },
+        run_name="tune_run",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: the config written to disk still carries the forced invariants —
+    #       min_adj_peak 0.0, adjustment_factor 1.0, thresholds_config null —
+    #       while non-forced merge keys keep their override/base values
+    with open(ctx.config_path) as f:
+        written = yaml.safe_load(f)
+    assert written["merge"]["min_adj_peak"] == pytest.approx(0.0)
+    assert written["merge"]["adjustment_factor"] == pytest.approx(1.0)
+    assert written["merge"]["thresholds_config"] is None
+    # Non-forced keys follow normal precedence: override wins over base.
+    assert written["merge"]["agreement"] == 4
+    # Sectioned resolution happened: flat config, no section keys, no
+    # leakage from the predict section.
+    assert "shared" not in written and "predict" not in written
+    assert "model" not in written
+
+
+def test_prepare_run_extra_defaults_fill_gaps_but_never_override(tmp_path):
+    # Given: a flat tune-style base config that sets merge.min_distance_m=7.5
+    #        and tuning.metric=mae but omits the other merge/tuning keys
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "merge": {"min_distance_m": 7.5},
+                "tuning": {"metric": "mae"},
+            }
+        )
+    )
+
+    # When: prepare_run builds a TUNE run with no overrides
+    ctx = prepare_run(TUNE, base, run_name="r", run_root=tmp_path / "runs")
+
+    # Then: explicit base values survive (7.5, mae) while absent keys are
+    #       filled from TUNE.extra_defaults (agreement 1, ridge_probes 5,
+    #       cutoff_min 0.0001, reference.type "vector")
+    cfg = ctx.config
+    assert cfg["merge"]["min_distance_m"] == pytest.approx(7.5)
+    assert cfg["merge"]["agreement"] == 1
+    assert cfg["tuning"]["metric"] == "mae"
+    assert cfg["tuning"]["ridge_probes"] == 5
+    assert cfg["tuning"]["cutoff_min"] == pytest.approx(1.0e-4)
+    assert cfg["tuning"]["reference"] == {"type": "vector"}
+
+
+def test_prepare_run_forces_artifact_paths_into_run_dir(tmp_path):
+    # Given: a TUNE base config and an override that points merge.output
+    #        somewhere outside the run directory
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"tune": {"tuning": {"metric": "rms"}}}))
+    run_root = tmp_path / "runs"
+
+    # When: prepare_run builds the run
+    ctx = prepare_run(
+        TUNE,
+        base,
+        overrides={"merge.output": "/elsewhere/out.gpkg"},
+        run_name="myrun",
+        run_root=run_root,
+    )
+
+    # Then: every artifact path is rewritten to the fixed location inside
+    #       <run_root>/tune/<run_name>, the fixed subfolders exist on disk,
+    #       and the resolved config lands at <run_dir>/config.yaml
+    run_dir = run_root / "tune" / "myrun"
+    assert ctx.run_dir == run_dir
+    assert ctx.config_path == run_dir / "config.yaml"
+    assert ctx.config_path.is_file()
+    assert ctx.config["merge"]["output"] == str(run_dir / "merged_raw/merged_raw.gpkg")
+    assert ctx.config["tuning"]["out_dir"] == str(run_dir / "tuning")
+    assert ctx.config["tuning"]["best_params"] == str(
+        run_dir / "tuning/best_params.yaml"
+    )
+    assert ctx.config["tuning"]["final_output"] == str(
+        run_dir / "merged/merged_tuned.gpkg"
+    )
+    for sub in ("logs", "merged", "merged_raw", "tuning"):
+        assert (run_dir / sub).is_dir()
+
+
+def test_prepare_run_does_not_mutate_the_pipeline_spec(tmp_path):
+    # Given: the shared TUNE spec and a tune base config
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"tune": {"tuning": {"metric": "rms"}}}))
+
+    # When: prepare_run applies overrides that write into paths whose values
+    #       originate from extra_defaults (tuning.reference.type)
+    prepare_run(
+        TUNE,
+        base,
+        overrides={"tuning.reference.type": "raster", "merge.agreement": 12},
+        run_name="first",
+        run_root=tmp_path / "runs",
+    )
+
+    # Then: TUNE.extra_defaults is untouched
+    assert TUNE.extra_defaults["tuning"]["reference"] == {"type": "vector"}
+    assert TUNE.extra_defaults["merge"]["agreement"] == 1
+
+    # When: a second run is prepared without overrides
+    ctx2 = prepare_run(TUNE, base, run_name="second", run_root=tmp_path / "runs")
+
+    # Then: it still gets the pristine defaults
+    assert ctx2.config["tuning"]["reference"]["type"] == "vector"
+    assert ctx2.config["merge"]["agreement"] == 1
+
+
+def test_prepare_run_predict_fills_documented_merge_defaults(tmp_path):
+    # Given: a minimal flat base config with no merge section at all
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"geotiff_dir": "/tifs"}))
+
+    # When: prepare_run builds a PREDICT run with no overrides
+    ctx = prepare_run(PREDICT, base, run_name="r", run_root=tmp_path / "runs")
+
+    # Then: the resolved config carries exactly the documented merge
+    #       defaults — min_distance_m 3.0, agreement 1 (single-model runs
+    #       keep every point), min_adj_peak 0.0, adjustment_factor 1.0,
+    #       and null thresholds_config / exclusion_zones_gpkg /
+    #       inclusion_zone — plus merge.output, which is artifact-forced
+    #       into the run directory rather than defaulted
+    merge = dict(ctx.config["merge"])
+    assert merge.pop("output") == str(ctx.run_dir / "merged/merged.gpkg")
+    assert merge == {
+        "min_distance_m": 3.0,
+        "agreement": 1,
+        "min_adj_peak": 0.0,
+        "adjustment_factor": 1.0,
+        "thresholds_config": None,
+        "exclusion_zones_gpkg": None,
+        "inclusion_zone": None,
+    }
+
+
+def test_prepare_run_predict_artifacts_chain_the_stages_through_run_dir(tmp_path):
+    # Given: a flat predict base config pointing the stage folders at
+    #        locations outside the run directory
+    base = tmp_path / "base.yaml"
+    base.write_text(
+        yaml.safe_dump(
+            {
+                "manifest_folder": "/elsewhere/manifests",
+                "prediction": {"input_folder": "/elsewhere/preds"},
+            }
+        )
+    )
+
+    # When: prepare_run builds a PREDICT run
+    ctx = prepare_run(PREDICT, base, run_name="p", run_root=tmp_path / "runs")
+
+    # Then: the scanner's manifest_folder and the predictor's input_folder
+    #       both resolve to <run_dir>/manifests (predict reads exactly what
+    #       scan wrote), predictions land in <run_dir>/preds, and the merge
+    #       output at <run_dir>/merged/merged.gpkg — the base values lose
+    run_dir = tmp_path / "runs" / "predict" / "p"
+    assert ctx.run_dir == run_dir
+    assert ctx.config["manifest_folder"] == str(run_dir / "manifests")
+    assert ctx.config["prediction"]["input_folder"] == str(run_dir / "manifests")
+    assert ctx.config["prediction"]["output_folder"] == str(run_dir / "preds")
+    assert ctx.config["merge"]["output"] == str(run_dir / "merged/merged.gpkg")
+
+
+def test_prepare_run_train_artifacts_chain_the_stages_through_run_dir(tmp_path):
+    # Given: a flat train base config pointing the manifest elsewhere
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"manifest": "/elsewhere/old.parquet"}))
+
+    # When: prepare_run builds a TRAIN run
+    ctx = prepare_run(TRAIN, base, run_name="t", run_root=tmp_path / "runs")
+
+    # Then: manifest_folder resolves to <run_dir>/manifests, the
+    #       rebalancer's output and the trainer's manifest both to
+    #       <run_dir>/dataset/balanced.parquet (train reads exactly what
+    #       rebalance wrote), and model artifacts to <run_dir>/model
+    run_dir = tmp_path / "runs" / "train" / "t"
+    assert ctx.run_dir == run_dir
+    assert ctx.config["manifest_folder"] == str(run_dir / "manifests")
+    assert ctx.config["rebalancing"]["out"] == str(run_dir / "dataset/balanced.parquet")
+    assert ctx.config["manifest"] == str(run_dir / "dataset/balanced.parquet")
+    assert ctx.config["artifact_dir"] == str(run_dir / "model")
+
+
+def test_stage_argv_runs_the_stage_module_on_the_resolved_config(tmp_path):
+    # Given: a prepared PREDICT run context and its scan stage
+    base = tmp_path / "base.yaml"
+    base.write_text(yaml.safe_dump({"geotiff_dir": "/tifs"}))
+    ctx = prepare_run(PREDICT, base, run_name="r", run_root=tmp_path / "runs")
+    scan = PREDICT.stages[1]
+    assert scan.key == "scan"
+
+    # When: stage_argv builds the stage command line
+    argv = stage_argv(ctx, scan)
+
+    # Then: it is exactly [current interpreter, -m, the stage's module,
+    #       the resolved config written into the run dir] — every stage
+    #       executes against the run's own config.yaml, nothing else
+    assert argv == [
+        sys.executable,
+        "-m",
+        "displacement_tracker.b2_image_scanner",
+        str(ctx.run_dir / "config.yaml"),
+    ]
+
+
+def test_download_stage_is_opt_in_for_predict_and_train():
+    # Given: the shipped PREDICT and TRAIN specs
+    # When: a frontend selects the stages to run by their defaults
+    predict_stages = [(s.key, s.default_enabled) for s in PREDICT.stages]
+    train_stages = [(s.key, s.default_enabled) for s in TRAIN.stages]
+
+    # Then: "download" is the only stage disabled by default in both
+    #       pipelines — otherwise every default run would re-download
+    #       GeoTIFFs from Drive, clobbering curated local imagery — and
+    #       the remaining stages run in their documented order
+    assert predict_stages == [
+        ("download", False),
+        ("scan", True),
+        ("predict", True),
+        ("merge", True),
+    ]
+    assert train_stages == [
+        ("download", False),
+        ("scan", True),
+        ("rebalance", True),
+        ("train", True),
+    ]
+
+
+def test_default_run_root_prefers_data_dir(monkeypatch):
+    # Given: DATA_DIR set in the environment, and default_run_root's
+    #        load_dotenv() call stubbed out so a developer's .env cannot
+    #        contribute a value either way
+    monkeypatch.setattr(
+        "displacement_tracker.pipelines.runner.load_dotenv", lambda: None
+    )
+    monkeypatch.setenv("DATA_DIR", "/big/disk")
+
+    # When: default_run_root resolves the run root
+    root = default_run_root()
+
+    # Then: it is <DATA_DIR>/results/TentNetFA/pipeline_runs
+    assert root == os.path.join("/big/disk", "results", "TentNetFA", "pipeline_runs")
+
+
+def test_default_run_root_falls_back_to_local_repo(monkeypatch):
+    # Given: no DATA_DIR in the environment, with load_dotenv() stubbed so
+    #        a local .env cannot put it back (clearing the variable alone
+    #        would not survive the load_dotenv() inside default_run_root)
+    monkeypatch.setattr(
+        "displacement_tracker.pipelines.runner.load_dotenv", lambda: None
+    )
+    monkeypatch.delenv("DATA_DIR", raising=False)
+
+    # When: default_run_root resolves the run root
+    root = default_run_root()
+
+    # Then: it falls back to the repo-local runs/pipelines
+    assert root == os.path.join("runs", "pipelines")

--- a/tests/test_scan_orchestrator.py
+++ b/tests/test_scan_orchestrator.py
@@ -1,0 +1,171 @@
+"""Unit tests for displacement_tracker/util/scan_orchestrator.py.
+
+Covers tif collection and its substring filter, the per-TIFF scan loop and
+manifest writer lifecycle, and presence-based config-key validation.
+
+This module is the per-TIFF orchestration shared by the tiling scanners
+(b1_annotated_scanner, b2_image_scanner) — its only two consumers.
+"""
+
+import pandas as pd
+import pytest
+
+from displacement_tracker.util.manifest_writer import MANIFEST_COLUMNS
+from displacement_tracker.util.scan_orchestrator import (
+    collect_tif_files,
+    require_keys,
+    run_scans,
+)
+
+
+# ---------------------------------------------------------------------------
+# scan_orchestrator.collect_tif_files
+# ---------------------------------------------------------------------------
+
+
+def test_collect_tif_files_returns_all_tifs_without_filter(tmp_path):
+    # Given: a directory with two .tif files and one .txt file
+    (tmp_path / "a.tif").touch()
+    (tmp_path / "b.tif").touch()
+    (tmp_path / "c.txt").touch()
+
+    # When: collect_tif_files runs with no params, and with an empty filter
+    unfiltered = collect_tif_files(str(tmp_path))
+    empty_filter = collect_tif_files(str(tmp_path), {"loading": {"files": []}})
+
+    # Then: exactly the two .tif files are returned either way
+    expected = {str(tmp_path / "a.tif"), str(tmp_path / "b.tif")}
+    assert set(unfiltered) == expected
+    assert set(empty_filter) == expected
+
+
+def test_collect_tif_files_substring_filter(tmp_path):
+    # Given: scene_alpha.tif and scene_beta.tif with loading.files=["alpha",
+    #        "gamma"]
+    (tmp_path / "scene_alpha.tif").touch()
+    (tmp_path / "scene_beta.tif").touch()
+    params = {"loading": {"files": ["alpha", "gamma"]}}
+
+    # When: collect_tif_files applies the filter
+    matched = collect_tif_files(str(tmp_path), params)
+
+    # Then: only files whose basename contains a search string survive; a
+    #       search string matching nothing adds nothing
+    assert matched == [str(tmp_path / "scene_alpha.tif")]
+
+
+# ---------------------------------------------------------------------------
+# scan_orchestrator.run_scans: manifest lifecycle on real Parquet files
+# ---------------------------------------------------------------------------
+
+
+def _manifest_row(raster_path: str) -> dict:
+    """A complete manifest row describing one tile of ``raster_path``.
+
+    The key set is checked against the writer's own MANIFEST_COLUMNS, so a
+    column added or removed upstream fails here naming the difference in
+    both directions.
+    """
+    row = {
+        "tile_id": 1,
+        "raster_path": raster_path,
+        "prewar_path": "pre.tif",
+        "labels_path": "labels.json",
+        "r0": 0,
+        "r1": 256,
+        "c0": 0,
+        "c1": 256,
+        "lon_min": 34.0,
+        "lon_max": 34.1,
+        "lat_min": 31.0,
+        "lat_max": 31.1,
+        "origin_image": "scene",
+        "origin_date": "2023-01-01",
+        "valid_fraction": 1.0,
+        "is_complete": True,
+        "label_feature_ids": [1, 2],
+    }
+    assert set(row) == set(MANIFEST_COLUMNS), (
+        "manifest row does not match MANIFEST_COLUMNS: "
+        f"missing {sorted(set(MANIFEST_COLUMNS) - set(row))}, "
+        f"unexpected {sorted(set(row) - set(MANIFEST_COLUMNS))}"
+    )
+    return row
+
+
+def test_run_scans_writes_one_parquet_per_tif(tmp_path):
+    # Given: two tif paths and a callback that writes one manifest row per tif
+    manifest_folder = tmp_path / "manifests"
+    tifs = [str(tmp_path / "scene_a.tif"), str(tmp_path / "scene_b.tif")]
+
+    def scan_one(tif_path, writer):
+        writer.add_row(_manifest_row(tif_path))
+
+    # When: run_scans drives the loop
+    run_scans(tifs, scan_one, manifest_folder=str(manifest_folder))
+
+    # Then: one Parquet file per tif exists, named for that tif's stem, each
+    #       holding exactly the row written for that tif
+    for tif, expected_name in zip(tifs, ("scene_a.parquet", "scene_b.parquet")):
+        out = manifest_folder / expected_name
+        assert out.is_file()
+        df = pd.read_parquet(out)
+        assert len(df) == 1
+        assert df.loc[0, "raster_path"] == tif
+
+
+def test_run_scans_flushes_manifest_when_callback_raises(tmp_path):
+    # Given: a callback that writes one row and then raises
+    manifest_folder = tmp_path / "manifests"
+    tif = str(tmp_path / "scene_x.tif")
+
+    def scan_one(tif_path, writer):
+        writer.add_row(_manifest_row(tif_path))
+        raise RuntimeError("scan blew up")
+
+    # When: run_scans processes the tif
+    # Then: the exception propagates
+    with pytest.raises(RuntimeError, match="scan blew up"):
+        run_scans([tif], scan_one, manifest_folder=str(manifest_folder))
+
+    # Then: the manifest is still closed and written with the row that made it
+    #       in (the finally-block contract)
+    out = manifest_folder / "scene_x.parquet"
+    assert out.is_file()
+    assert len(pd.read_parquet(out)) == 1
+
+
+def test_run_scans_empty_input_is_a_noop(tmp_path):
+    # Given: an empty tif list and a callback that must never be reached
+    manifest_folder = tmp_path / "manifests"
+
+    def scan_one(tif_path, writer):
+        raise AssertionError("must not be called")
+
+    # When: run_scans runs
+    run_scans([], scan_one, manifest_folder=str(manifest_folder))
+
+    # Then: it returns without raising and never creates the manifest folder
+    assert not manifest_folder.exists()
+
+
+# ---------------------------------------------------------------------------
+# scan_orchestrator.require_keys
+# ---------------------------------------------------------------------------
+
+
+def test_require_keys_checks_presence_not_truthiness():
+    # Given: a config whose keys are present but falsy (None / 0), and one
+    #        with a key absent altogether
+    falsy_present = {"a": None, "b": 0}
+    key_absent = {"a": 1}
+
+    # When: require_keys validates the config whose keys are all present
+    # Then: it accepts them — a configured-but-empty value is not a missing
+    #       one, so presence alone is the contract
+    require_keys(falsy_present, ("a", "b"))
+
+    # When: it validates the config with a key absent
+    # Then: KeyError names the absent key
+    with pytest.raises(KeyError, match="missing_key"):
+        require_keys(key_absent, ("a", "missing_key"))

--- a/tests/test_scan_validation.py
+++ b/tests/test_scan_validation.py
@@ -1,0 +1,737 @@
+"""Unit tests for displacement_tracker/g1_scan_validation.py.
+
+Covers settings resolution, metric resolution, the sign-adjusted objective,
+the evaluator/bests bookkeeping, the ridge scan core, prediction-date
+inference and best-params export.
+"""
+
+import math
+import os
+from datetime import datetime
+
+import click
+import numpy as np
+import pandas as pd
+import pytest
+import yaml
+
+from displacement_tracker.g1_scan_validation import (
+    LARGE_PENALTY,
+    ScanSettings,
+    make_evaluator,
+    objective,
+    optimize_metric,
+    prediction_date,
+    resolve_metrics,
+    scan_tile,
+    write_best_params,
+)
+from displacement_tracker.util.validation_core import initial_best_value, is_better
+
+
+def _settings(**overrides) -> ScanSettings:
+    base = dict(
+        input_path="merged_raw.gpkg",
+        pred_folder=None,
+        master_grid="grid.tif",
+        reference={"path": "ref.geojson"},
+        out_dir="scan_results",
+        best_params_path="scan_results/best_params.yaml",
+        metric="rms",
+        scan_metrics=["rms"],
+        factor_bounds=(0.0, 10.0),
+        cutoff_bounds=(0.0001, 0.01),
+        ridge_probes=5,
+        xtol_factor=1e-3,
+        xtol_cutoff=1e-6,
+        refine_maxiter=60,
+        exclusion_zones=None,
+    )
+    base.update(overrides)
+    return ScanSettings(**base)
+
+
+def _fresh_bests(scan_metrics):
+    return {
+        m: {
+            "value": initial_best_value(m),
+            "factor": None,
+            "cutoff": None,
+            "keep": None,
+        }
+        for m in scan_metrics
+    }
+
+
+def _grouped(points, val_counts, masked_out=()):
+    """Build the subset of the cell-input dict the evaluator reads.
+
+    Hand-built rather than produced by prepare_grouped_cell_inputs, because
+    stating each point's (row, col) directly is what makes the expected cell
+    arithmetic checkable. Nothing ties this dict to the producer — it also
+    returns nodata_val and out_transform, which the evaluator ignores — so a
+    key added upstream will not fail here.
+
+    ``points`` are (peak_value, adjusted_peak, row, col) prediction rows;
+    ``val_counts`` is the reference-count raster, whose shape sets grid_shape;
+    ``masked_out`` lists the (row, col) cells excluded from the analysis mask,
+    which defaults to every cell included.
+    """
+    peak_value, adjusted_peak, rows, cols = (list(v) for v in zip(*points))
+    val_raster = np.array(val_counts, dtype=np.float32)
+    mask_array = np.ones(val_raster.shape, dtype=bool)
+    for cell in masked_out:
+        mask_array[cell] = False
+    return {
+        "pred_prepped": pd.DataFrame(
+            {
+                "peak_value": peak_value,
+                "adjusted_peak": adjusted_peak,
+                "row": rows,
+                "col": cols,
+            }
+        ),
+        "val_raster": val_raster,
+        "mask_array": mask_array,
+        "grid_shape": val_raster.shape,
+    }
+
+
+# ---------------------------------------------------------------------------
+# resolve_metrics
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_metrics_defaults():
+    # Given: an empty tuning config
+    tuning = {}
+
+    # When: resolve_metrics runs
+    metric, metrics = resolve_metrics(tuning)
+
+    # Then: the eval metric defaults to "rms" and the tracked metrics to the
+    #       default triple (rms, mae, abs_total_diff), rms not duplicated
+    assert metric == "rms"
+    assert metrics == ["rms", "mae", "abs_total_diff"]
+
+
+def test_resolve_metrics_inserts_eval_metric_first():
+    # Given: metric=spearman which is absent from the default metric list
+    tuning = {"metric": "spearman"}
+
+    # When: resolve_metrics runs
+    metric, metrics = resolve_metrics(tuning)
+
+    # Then: spearman is prepended so the eval metric is always tracked
+    assert metric == "spearman"
+    assert metrics == ["spearman", "rms", "mae", "abs_total_diff"]
+
+
+def test_resolve_metrics_respects_explicit_list_containing_metric():
+    # Given: metric=mae and an explicit metrics list already containing it
+    tuning = {"metric": "mae", "metrics": ["mae", "rmsle"]}
+
+    # When: resolve_metrics runs
+    metric, metrics = resolve_metrics(tuning)
+
+    # Then: the explicit list is used verbatim (no insertion, no defaults)
+    assert metric == "mae"
+    assert metrics == ["mae", "rmsle"]
+
+
+def test_resolve_metrics_unknown_metric_raises():
+    # Given: an eval metric that is not in METRIC_DIRECTIONS
+    tuning = {"metric": "bogus"}
+
+    # When: resolve_metrics runs
+    # Then: a ClickException names the unknown metric
+    with pytest.raises(click.ClickException, match="bogus"):
+        resolve_metrics(tuning)
+
+
+# ---------------------------------------------------------------------------
+# ScanSettings.from_config
+# ---------------------------------------------------------------------------
+
+
+def test_scan_settings_defaults_and_merge_output_fallback():
+    # Given: a minimal config with no tuning.input but a merge.output
+    params = {
+        "tuning": {"master_grid": "grid.tif", "reference": {"path": "r.geojson"}},
+        "merge": {"output": "merged_raw.gpkg"},
+    }
+
+    # When: ScanSettings.from_config resolves it
+    s = ScanSettings.from_config(params)
+
+    # Then: the input falls back to merge.output and every optional knob gets
+    #       its documented default
+    assert s.input_path == "merged_raw.gpkg"
+    assert s.out_dir == "scan_results"
+    assert s.best_params_path == os.path.join("scan_results", "best_params.yaml")
+    assert s.metric == "rms"
+    assert s.scan_metrics == ["rms", "mae", "abs_total_diff"]
+    assert s.factor_bounds == (0.0, 10.0)
+    assert s.cutoff_bounds == (0.0001, 0.01)
+    assert s.ridge_probes == 5
+    assert s.xtol_factor == pytest.approx(1e-3)
+    assert s.xtol_cutoff == pytest.approx(1e-6)
+    assert s.refine_maxiter == 60
+    assert s.exclusion_zones is None
+    assert s.pred_folder is None
+
+
+def test_scan_settings_explicit_input_wins_and_pred_folder_from_merge():
+    # Given: both tuning.input and merge.output set, plus merge.input_folder
+    #        and a custom tuning.out_dir
+    params = {
+        "tuning": {
+            "input": "explicit.gpkg",
+            "master_grid": "grid.tif",
+            "reference": "r.geojson",
+            "out_dir": "custom_out",
+        },
+        "merge": {"output": "merged_raw.gpkg", "input_folder": "preds"},
+    }
+
+    # When: ScanSettings.from_config resolves it
+    s = ScanSettings.from_config(params)
+
+    # Then: tuning.input takes precedence and pred_folder comes from
+    #       merge.input_folder; the custom out_dir also relocates best_params
+    assert s.input_path == "explicit.gpkg"
+    assert s.pred_folder == "preds"
+    assert s.best_params_path == os.path.join("custom_out", "best_params.yaml")
+
+
+def test_scan_settings_missing_input_raises():
+    # Given: neither tuning.input nor merge.output present
+    params = {"tuning": {"master_grid": "g.tif", "reference": "r.geojson"}}
+
+    # When: ScanSettings.from_config resolves the config
+    # Then: a ClickException points at tuning.input / merge.output
+    with pytest.raises(click.ClickException, match="tuning.input"):
+        ScanSettings.from_config(params)
+
+
+def test_scan_settings_missing_required_keys_raise():
+    # Given: one config missing master_grid, and one that supplies master_grid
+    #        but no reference
+    no_master_grid = {"tuning": {"input": "m.gpkg"}}
+    no_reference = {"tuning": {"input": "m.gpkg", "master_grid": "g.tif"}}
+
+    # When: ScanSettings.from_config resolves the config missing master_grid
+    # Then: a ClickException names that dotted missing key
+    with pytest.raises(click.ClickException, match="tuning.master_grid"):
+        ScanSettings.from_config(no_master_grid)
+
+    # When: it resolves the config missing reference
+    # Then: a ClickException names that dotted missing key instead
+    with pytest.raises(click.ClickException, match="tuning.reference"):
+        ScanSettings.from_config(no_reference)
+
+
+def test_scan_settings_degenerate_bounds_raise():
+    # Given: an otherwise valid tuning config to layer degenerate bounds onto
+    tuning = {
+        "input": "m.gpkg",
+        "master_grid": "g.tif",
+        "reference": "r.geojson",
+    }
+
+    # When: ScanSettings.from_config validates factor_min == factor_max
+    # Then: the empty range is rejected with a ClickException
+    with pytest.raises(click.ClickException, match="strictly less"):
+        ScanSettings.from_config(
+            {"tuning": {**tuning, "factor_min": 2.0, "factor_max": 2.0}}
+        )
+
+    # When: it validates cutoff_min == cutoff_max
+    # Then: the empty range is rejected the same way. Equality is the
+    #       boundary of both comparisons, so a >= relaxed to > on either
+    #       one fails here — an inverted range would let that through.
+    with pytest.raises(click.ClickException, match="strictly less"):
+        ScanSettings.from_config(
+            {"tuning": {**tuning, "cutoff_min": 0.5, "cutoff_max": 0.5}}
+        )
+
+
+def test_scan_settings_base_name_strips_dir_and_extension():
+    # Given: an input path with directories and a .gpkg extension
+    s = _settings(input_path="/data/runs/merged_raw.gpkg")
+
+    # When: base_name is read
+    base_name = s.base_name
+
+    # Then: only the extension-free file stem remains
+    assert base_name == "merged_raw"
+
+
+# ---------------------------------------------------------------------------
+# objective (sign adjustment + penalties)
+# ---------------------------------------------------------------------------
+
+
+def test_objective_sign_and_penalties():
+    # Given: evaluators returning a min-metric, a max-metric, a failure (None),
+    #        a NaN and a dict missing the requested metric
+    def min_eval(factor, cutoff):
+        return {"rms": 2.5}
+
+    def max_eval(factor, cutoff):
+        return {"spearman": 0.7}
+
+    def failed_eval(factor, cutoff):
+        return None
+
+    def nan_eval(factor, cutoff):
+        return {"rms": float("nan")}
+
+    def missing_eval(factor, cutoff):
+        return {"mae": 1.0}
+
+    # When: objective converts each to the always-minimized scalar
+    # Then: min metrics pass through, max metrics are negated, and every
+    #       failure mode maps to LARGE_PENALTY
+    assert objective(min_eval, "rms", 0.0, 0.0) == 2.5
+    assert objective(max_eval, "spearman", 0.0, 0.0) == -0.7
+    assert objective(failed_eval, "rms", 0.0, 0.0) == LARGE_PENALTY
+    assert objective(nan_eval, "rms", 0.0, 0.0) == LARGE_PENALTY
+    assert objective(missing_eval, "rms", 0.0, 0.0) == LARGE_PENALTY
+
+
+# ---------------------------------------------------------------------------
+# make_evaluator: metric values, keep semantics, bests bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def _evaluator_fixture():
+    """2x2 grid, one masked-out cell, four candidate points.
+
+    Cell layout (row, col) -> reference counts:
+        (0,0)=2  (0,1)=0
+        (1,0)=0  (1,1)=1 but (1,1) is OUTSIDE the analysis mask
+    """
+    return _grouped(
+        points=[
+            (0.9, 0.9, 0, 0),
+            (0.1, 0.4, 0, 1),
+            (0.2, 0.2, 0, 0),
+            (0.05, 0.05, 1, 1),
+        ],
+        val_counts=[[2.0, 0.0], [0.0, 1.0]],
+        masked_out=[(1, 1)],
+    )
+
+
+def test_evaluator_scores_the_cells_the_cutoff_selects():
+    # Given: the 2x2 fixture wired to a fresh bests dict and an empty trace
+    grouped = _evaluator_fixture()
+    scan_metrics = ["rms", "mae", "abs_total_diff"]
+    bests = _fresh_bests(scan_metrics)
+    trace = []
+    evaluate = make_evaluator(grouped, scan_metrics, bests, trace)
+
+    # When: the evaluator scores factor=1, cutoff=0.3, so only the two points
+    #       with adjusted_peak >= 0.3 survive -> pred cells (0,0)=1, (0,1)=1;
+    #       in-mask pred=[1,1,0] vs val=[2,0,0]
+    m = evaluate(1.0, 0.3)
+
+    # Then: the surviving points are the ones counted — three in-mask cells,
+    #       so the masked cell (1,1) is excluded, and the totals are those of
+    #       the two survivors. The metric formulas themselves belong to
+    #       validation_core.compute_metrics and are pinned in
+    #       tests/test_validation_core.py.
+    assert m["n_cells"] == 3
+    assert m["total_pred"] == 2.0
+    assert m["total_val"] == 2.0
+    assert m["abs_total_diff"] == 0.0
+    assert m["total_pdiff"] == 0.0
+
+    # Then: the trace records that one evaluation with its scan metrics
+    assert len(trace) == 1
+    assert trace[0]["factor"] == 1.0
+    assert trace[0]["cutoff"] == 0.3
+    assert set(scan_metrics) <= set(trace[0])
+
+    # Then: bests picks it up, carrying through the value the evaluator
+    #       computed and the keep mask of the two survivors
+    assert bests["rms"]["value"] == pytest.approx(m["rms"])
+    assert bests["rms"]["factor"] == 1.0
+    assert bests["rms"]["cutoff"] == 0.3
+    np.testing.assert_array_equal(bests["rms"]["keep"], [True, True, False, False])
+
+
+def test_evaluator_per_metric_bests_and_ties():
+    # Given: the 2x2 fixture wired to a bests dict and trace shared across
+    #        every evaluation below
+    grouped = _evaluator_fixture()
+    scan_metrics = ["rms", "mae", "abs_total_diff"]
+    bests = _fresh_bests(scan_metrics)
+    trace = []
+    evaluate = make_evaluator(grouped, scan_metrics, bests, trace)
+
+    # When: (1.0, 0.3) is scored, then (1.0, 0.04) which improves rms/mae but
+    #       worsens abs_total_diff
+    evaluate(1.0, 0.3)
+    m2 = evaluate(1.0, 0.04)  # keeps all 4 points: in-mask pred=[2,1,0]
+
+    # Then: rms/mae move to cutoff=0.04 while abs_total_diff stays at cutoff=0.3
+    assert m2["rms"] == pytest.approx(math.sqrt(1.0 / 3.0), rel=1e-6)
+    assert m2["abs_total_diff"] == 1.0
+    assert bests["rms"]["cutoff"] == 0.04
+    assert bests["mae"]["cutoff"] == 0.04
+    np.testing.assert_array_equal(bests["rms"]["keep"], [True, True, True, True])
+    # abs_total_diff got worse (1 > 0) so its best is untouched
+    assert bests["abs_total_diff"]["value"] == 0.0
+    assert bests["abs_total_diff"]["cutoff"] == 0.3
+
+    # When: (0.0, 0.3) is scored — factor=0 collapses rescaled peaks to
+    #       peak_value, so only the 0.9 point survives 0.3 and in-mask
+    #       pred=[1,0,0] gives rms=sqrt(1/3), an EXACT tie with the incumbent
+    m3 = evaluate(0.0, 0.3)
+
+    # Then: the tie does not displace the incumbent (strict improvement only),
+    #       and all three evaluations are traced
+    assert m3["total_pred"] == 1.0
+    assert m3["rms"] == pytest.approx(math.sqrt(1.0 / 3.0), rel=1e-6)
+    assert bests["rms"]["factor"] == 1.0
+    assert bests["rms"]["cutoff"] == 0.04
+    assert len(trace) == 3
+
+
+def test_evaluator_abs_total_pdiff_value_and_objective_pass_through():
+    # Given: a 1x2 fully-masked grid with reference counts [2, 0] and three
+    #        prediction points (two in cell (0,0), one in (0,1)) that all
+    #        survive factor=1, cutoff=0.5 -> pred=[2,1] vs val=[2,0], so
+    #        total_pred=3 and total_val=2
+    grouped = _grouped(
+        points=[(0.9, 0.9, 0, 0), (0.8, 0.8, 0, 0), (0.7, 0.7, 0, 1)],
+        val_counts=[[2.0, 0.0]],
+    )
+    scan_metrics = ["abs_total_pdiff"]
+    bests = _fresh_bests(scan_metrics)
+    trace = []
+    evaluate = make_evaluator(grouped, scan_metrics, bests, trace)
+
+    # When: the evaluator computes the metrics at that point
+    m = evaluate(1.0, 0.5)
+
+    # Then: abs_total_pdiff = |(3 - 2) / 2| = 0.5, and it becomes the best
+    assert m["total_pred"] == 3.0
+    assert m["total_val"] == 2.0
+    assert m["total_pdiff"] == pytest.approx(0.5)
+    assert m["abs_total_pdiff"] == pytest.approx(0.5)
+    assert bests["abs_total_pdiff"]["value"] == pytest.approx(0.5)
+
+    # When: objective consumes the abs_total_pdiff metric at the same point
+    # Then: it returns the value unnegated (+0.5) because abs_total_pdiff is
+    #       minimized
+    assert objective(evaluate, "abs_total_pdiff", 1.0, 0.5) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# optimize_metric: ridge fit, along-ridge clipping, Nelder-Mead seeding
+# ---------------------------------------------------------------------------
+
+
+def _recording_evaluator(objective_fn, metric="rms", incumbent=None):
+    """An evaluator over ``objective_fn(factor, cutoff)``, plus its call log.
+
+    Returns ``(evaluate, calls, bests)``. ``calls`` records every
+    ``(factor, cutoff)`` the search visits, in order. ``bests`` starts fresh
+    unless ``incumbent`` supplies a starting entry, and tracks the best
+    value the same way make_evaluator does — which is what lets these tests
+    drive optimize_metric without building a grouped-cell fixture.
+    """
+    calls = []
+    bests = (
+        {metric: dict(incumbent, keep=None)}
+        if incumbent is not None
+        else _fresh_bests([metric])
+    )
+
+    def evaluate(factor, cutoff):
+        calls.append((float(factor), float(cutoff)))
+        value = float(objective_fn(float(factor), float(cutoff)))
+        if is_better(metric, value, bests[metric]["value"]):
+            bests[metric] = {
+                "value": value,
+                "factor": float(factor),
+                "cutoff": float(cutoff),
+                "keep": None,
+            }
+        return {metric: value}
+
+    return evaluate, calls, bests
+
+
+def test_optimize_metric_ridge_fit_recovers_linear_ridge():
+    # Given: a synthetic objective (cutoff - (0.3*factor + 0.05))**2 whose
+    #        best cutoff at each factor lies exactly on the line
+    #        cutoff = 0.3*factor + 0.05, strictly inside the cutoff bounds at
+    #        all three probe factors (0 -> 0.05, 1 -> 0.35, 2 -> 0.65)
+    evaluate, _, bests = _recording_evaluator(
+        lambda factor, cutoff: (cutoff - (0.3 * factor + 0.05)) ** 2
+    )
+
+    # When: optimize_metric probes the ridge (Phase 1) and fits
+    #       cutoff = a*factor + b through the probe optima (Phase 2)
+    a, b = optimize_metric(
+        evaluate=evaluate,
+        metric="rms",
+        bests=bests,
+        factor_bounds=(0.0, 2.0),
+        cutoff_bounds=(0.0, 1.0),
+        n_probes=3,
+        xtol_factor=1e-3,
+        xtol_cutoff=1e-6,
+        refine_maxiter=0,
+    )
+
+    # Then: the returned coefficients recover (a, b) = (0.3, 0.05) — the fit
+    #       regresses cutoff on factor, not factor on cutoff
+    assert a == pytest.approx(0.3, abs=1e-2)
+    assert b == pytest.approx(0.05, abs=1e-2)
+
+
+def test_optimize_metric_along_ridge_cutoff_clipped_to_cutoff_bounds():
+    # Given: a tight cutoff box (0.2, 0.25) inside wide factor bounds (0, 10)
+    #        and an objective whose per-factor best cutoff
+    #        0.25 + 0.003*f - 0.0008*f**2 leaves the box at both ends, so the
+    #        Phase-1 probe optima (f=0, 5, 10) pin near (0.25, 0.245, 0.2) and
+    #        the Phase-2 least-squares line b ~ 0.257 overshoots cutoff_max
+    #        near factor 0; the + 0.001*factor term pulls the Phase-3
+    #        along-ridge search toward factor 0, exactly where the fitted
+    #        line extrapolates out of the box
+    def ridge_objective(factor, cutoff):
+        ridge_cutoff = 0.25 + 0.003 * factor - 0.0008 * factor**2
+        return (cutoff - ridge_cutoff) ** 2 + 0.001 * factor
+
+    evaluate, calls, bests = _recording_evaluator(ridge_objective)
+
+    # When: optimize_metric walks along the fitted ridge
+    optimize_metric(
+        evaluate=evaluate,
+        metric="rms",
+        bests=bests,
+        factor_bounds=(0.0, 10.0),
+        cutoff_bounds=(0.2, 0.25),
+        n_probes=3,
+        xtol_factor=1e-3,
+        xtol_cutoff=1e-6,
+        refine_maxiter=0,
+    )
+
+    # Then: every evaluated cutoff — the Phase-3 ones included — is clipped
+    #       into the CUTOFF bounds, and the best cutoff found lies in the box
+    assert len(calls) > 3
+    assert all(0.2 <= c <= 0.25 for _, c in calls)
+    assert 0.2 <= bests["rms"]["cutoff"] <= 0.25
+
+
+def test_optimize_metric_nelder_mead_seeded_at_incumbent():
+    # Given: a runner over a flat objective (every evaluation returns rms=1.0,
+    #        never a strict improvement, so the bests dict stays untouched)
+    #        with an incumbent best pinned beforehand at the asymmetric point
+    #        (factor=0.7, cutoff=0.2), which no Phase 1-3 evaluation hits
+    #        (probe factors are 0 and 2; Brent visits golden-section points)
+    def run(refine_maxiter):
+        evaluate, calls, bests = _recording_evaluator(
+            lambda factor, cutoff: 1.0,
+            incumbent={"value": 1.0, "factor": 0.7, "cutoff": 0.2},
+        )
+        optimize_metric(
+            evaluate=evaluate,
+            metric="rms",
+            bests=bests,
+            factor_bounds=(0.0, 2.0),
+            cutoff_bounds=(0.0, 1.0),
+            n_probes=2,
+            xtol_factor=1e-2,
+            xtol_cutoff=1e-2,
+            refine_maxiter=refine_maxiter,
+        )
+        return calls
+
+    # When: optimize_metric runs once with refine_maxiter=0 (Phases 1-3 only)
+    #       and once with refine_maxiter=5 (adding Phase 4), both recording
+    #       every evaluated point
+    phases_1_to_3 = run(0)
+    with_refine = run(5)
+
+    # Then: the call sequences agree over Phases 1-3, and the first Phase-4
+    #       evaluation is exactly the incumbent (factor, cutoff) — in that
+    #       order — where Nelder-Mead must be seeded
+    assert with_refine[: len(phases_1_to_3)] == phases_1_to_3
+    assert len(with_refine) > len(phases_1_to_3)
+    assert with_refine[len(phases_1_to_3)] == (0.7, 0.2)
+
+
+# ---------------------------------------------------------------------------
+# scan_tile: the ridge-scan core
+# ---------------------------------------------------------------------------
+
+
+def test_scan_tile_finds_separating_cutoff():
+    # Given: one signal point (rescaled peak 0.5 at a cell with reference
+    #        count 1) and one noise point (rescaled peak 0.0 at a count-0
+    #        cell); any cutoff in (0, 0.5] yields a perfect rms of 0
+    grouped = _grouped(
+        points=[(0.5, 0.5, 0, 0), (0.0, 0.0, 0, 1)],
+        val_counts=[[1.0, 0.0]],
+    )
+
+    # When: scan_tile searches factor in [0,2] and cutoff in [0.01, 1.0]
+    bests, trace, ridges = scan_tile(
+        grouped=grouped,
+        factor_bounds=(0.0, 2.0),
+        cutoff_bounds=(0.01, 1.0),
+        scan_metrics=("rms",),
+        n_probes=3,
+        xtol_factor=1e-2,
+        xtol_cutoff=1e-3,
+        refine_maxiter=10,
+    )
+
+    # Then: the best rms is exactly 0, achieved with a cutoff in (0.01, 0.5]
+    #       that keeps only the signal point
+    best = bests["rms"]
+    assert best["value"] == 0.0
+    assert 0.01 <= best["cutoff"] <= 0.5
+    assert 0.0 <= best["factor"] <= 2.0
+    np.testing.assert_array_equal(best["keep"], [True, False])
+
+    # Then: scan_tile returns exactly one ridge per scan metric, each the
+    #       (a, b) of the fitted cutoff = a*factor + b. What those
+    #       coefficients mean is pinned by
+    #       test_optimize_metric_ridge_fit_recovers_linear_ridge, which
+    #       recovers a known line.
+    assert set(ridges) == {"rms"}
+    assert len(ridges["rms"]) == 2
+
+    # Then: every visited point stays inside the bounds. Phase 1 alone runs
+    #       n_probes bounded Brent searches, each evaluating at least once, so
+    #       the trace cannot be shorter than n_probes.
+    assert len(trace) >= 3
+    for t in trace:
+        assert 0.0 <= t["factor"] <= 2.0
+        assert 0.01 - 1e-9 <= t["cutoff"] <= 1.0 + 1e-9
+
+
+def test_scan_tile_metric_never_finite_leaves_best_unset():
+    # Given: a reference raster of all zeros, so val never varies and
+    #        spearman is NaN at every evaluation
+    grouped = _grouped(
+        points=[(0.5, 0.5, 0, 0), (0.1, 0.1, 0, 1)],
+        val_counts=[[0.0, 0.0]],
+    )
+
+    # When: scan_tile optimizes the spearman metric alone
+    bests, trace, _ = scan_tile(
+        grouped=grouped,
+        factor_bounds=(0.0, 1.0),
+        cutoff_bounds=(0.01, 1.0),
+        scan_metrics=("spearman",),
+        n_probes=2,
+        xtol_factor=0.1,
+        xtol_cutoff=0.05,
+        refine_maxiter=5,
+    )
+
+    # Then: no evaluation ever counts as an improvement — factor/cutoff stay
+    #       None and the value stays at the -inf sentinel
+    assert bests["spearman"]["factor"] is None
+    assert bests["spearman"]["cutoff"] is None
+    assert bests["spearman"]["value"] == -float("inf")
+    # Guard against a vacuous all(): the two Phase-1 probes each evaluate.
+    assert len(trace) >= 2
+    assert all(math.isnan(t["spearman"]) for t in trace)
+
+
+# ---------------------------------------------------------------------------
+# prediction_date: date parsing / median selection on real files
+# ---------------------------------------------------------------------------
+
+
+def test_prediction_date_median_ignores_non_point_files(tmp_path):
+    # Given: three date-stamped point files (mixed YYYYMMDD / YYYY-MM-DD
+    #        stamps and extensions) plus a .txt file with an earlier date
+    for name in (
+        "pred_20230101.geojson",
+        "pred_2023-06-01.gpkg",
+        "pred_20231215.json",
+        "notes_20200101.txt",
+    ):
+        (tmp_path / name).touch()
+    s = _settings(pred_folder=str(tmp_path))
+
+    # When: prediction_date infers the target date
+    inferred = prediction_date(s)
+
+    # Then: it returns the median of the three point-file dates, ignoring
+    #       the .txt file entirely
+    assert inferred == datetime(2023, 6, 1)
+
+
+def test_prediction_date_even_count_and_missing_folder(tmp_path):
+    # Given: a folder holding two date-stamped files (an even count)
+    (tmp_path / "a_20230101.geojson").touch()
+    (tmp_path / "b_20230601.geojson").touch()
+
+    # When: prediction_date runs on that folder
+    even_count = prediction_date(_settings(pred_folder=str(tmp_path)))
+
+    # Then: the even count picks the upper median (index len//2)
+    assert even_count == datetime(2023, 6, 1)
+
+    # When: it runs with no folder set and with a nonexistent folder
+    unset = prediction_date(_settings(pred_folder=None))
+    missing = str(tmp_path / "does_not_exist")
+    nonexistent = prediction_date(_settings(pred_folder=missing))
+
+    # Then: both return None
+    assert unset is None
+    assert nonexistent is None
+
+
+# ---------------------------------------------------------------------------
+# write_best_params: serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_write_best_params_yaml_round_trip(tmp_path):
+    # Given: bests for two metrics with mae chosen as the eval metric, and a
+    #        best_params path inside a not-yet-existing subdirectory
+    bests = {
+        "mae": {"value": 0.25, "factor": 1.5, "cutoff": 0.004, "keep": None},
+        "rms": {"value": 0.5, "factor": 2.0, "cutoff": 0.005, "keep": None},
+    }
+    path = tmp_path / "sub" / "best_params.yaml"
+    s = _settings(
+        input_path="/runs/merged_raw.gpkg",
+        metric="mae",
+        scan_metrics=["mae", "rms"],
+        best_params_path=str(path),
+    )
+
+    # When: write_best_params writes the YAML
+    returned = write_best_params(s, bests, bests["mae"])
+
+    # Then: the file parses back with (factor, cutoff) renamed to the merge
+    #       keys (adjustment_factor, min_adj_peak), the chosen metric at top
+    #       level, and every tracked metric under "bests"
+    assert path.is_file()
+    with open(path, encoding="utf-8") as f:
+        loaded = yaml.safe_load(f)
+    assert loaded == returned
+    assert loaded["metric"] == "mae"
+    assert loaded["value"] == pytest.approx(0.25)
+    assert loaded["adjustment_factor"] == pytest.approx(1.5)
+    assert loaded["min_adj_peak"] == pytest.approx(0.004)
+    assert loaded["input"] == "/runs/merged_raw.gpkg"
+    assert loaded["bests"]["rms"] == {
+        "value": 0.5,
+        "adjustment_factor": 2.0,
+        "min_adj_peak": 0.005,
+    }

--- a/tests/test_validation_core.py
+++ b/tests/test_validation_core.py
@@ -1,0 +1,178 @@
+"""Unit tests for displacement_tracker/util/validation_core.py.
+
+Covers the per-tile error metrics computed inside the analysis mask — the
+formulas themselves, the totals they derive from, and the degenerate
+branches (an empty mask, a zero reference total, and inputs too constant
+to rank) — plus the direction comparison every metric is optimized
+through.
+
+These pin ``compute_metrics`` and ``is_better`` directly. The tuning scan
+reaches both through a closure over one tile's grouped cell inputs; the
+scan's own tests pin that composition — which cells a ``(factor, cutoff)``
+pair selects — rather than restating these formulas.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from displacement_tracker.util.validation_core import compute_metrics, is_better
+
+LN2, LN3 = math.log(2.0), math.log(3.0)
+
+
+def _masked_tile():
+    """A 2x2 tile whose bottom-right cell is outside the analysis mask.
+
+    In-mask cells (row, col) -> (pred, val):
+        (0,0) -> (1, 2)    (0,1) -> (1, 0)    (1,0) -> (0, 0)
+
+    The masked-out cell holds pred == val == 9, large enough that every
+    metric below would move if it were counted. ``error_raster`` carries
+    log1p(pred) - log1p(val) per cell, which is what the caller supplies.
+    """
+    pred = np.array([[1.0, 1.0], [0.0, 9.0]], dtype=np.float32)
+    val = np.array([[2.0, 0.0], [0.0, 9.0]], dtype=np.float32)
+    error = np.array([[LN2 - LN3, LN2], [0.0, 0.0]], dtype=np.float64)
+    mask = np.array([[True, True], [True, False]])
+    return pred, val, error, mask
+
+
+def test_compute_metrics_error_formulas_over_the_masked_cells():
+    # Given: in-mask pred [1, 1, 0] against val [2, 0, 0] — differences
+    #        [-1, 1, 0] and log errors [ln2-ln3, ln2, 0] — plus a masked-out
+    #        cell holding 9s
+    pred, val, error, mask = _masked_tile()
+
+    # When: compute_metrics scores the tile
+    m = compute_metrics(pred, val, error, mask)
+
+    # Then: only the three in-mask cells contribute, and each formula matches
+    #       the value derived by hand: rms the root mean square of the
+    #       differences, mae their mean magnitude, rmsle the root mean square
+    #       of the supplied log errors
+    assert m["n_cells"] == 3
+    assert m["rms"] == pytest.approx(math.sqrt(2.0 / 3.0), rel=1e-6)
+    assert m["mae"] == pytest.approx(2.0 / 3.0, rel=1e-6)
+    assert m["rmsle"] == pytest.approx(
+        math.sqrt(((LN2 - LN3) ** 2 + LN2**2) / 3.0), rel=1e-6
+    )
+
+    # Then: spearman is the Pearson correlation of the ranks — pred ranks
+    #       [2.5, 2.5, 1] against val ranks [3, 1.5, 1.5] give exactly 0.5
+    assert m["spearman"] == pytest.approx(0.5, abs=1e-12)
+
+
+def test_compute_metrics_totals_and_percentage_difference():
+    # Given: an under-predicting tile — in-mask predictions summing to 1
+    #        against a reference summing to 2 — so the signed and absolute
+    #        totals genuinely differ
+    pred = np.array([[1.0, 0.0]], dtype=np.float32)
+    val = np.array([[2.0, 0.0]], dtype=np.float32)
+
+    # When: compute_metrics scores the tile
+    m = compute_metrics(pred, val, np.zeros((1, 2)), np.ones((1, 2), dtype=bool))
+
+    # Then: the signed fields carry the shortfall while the abs_ fields drop
+    #       the sign. abs_total_diff is one of the default scan objectives, so
+    #       an unsigned one would improve without bound as the scan
+    #       under-predicts and export a cutoff that discards every detection.
+    assert m["total_pred"] == 1.0
+    assert m["total_val"] == 2.0
+    assert m["total_diff"] == pytest.approx(-1.0)
+    assert m["abs_total_diff"] == pytest.approx(1.0)
+
+    # Then: the percentage difference is taken against the reference total,
+    #       not the predicted one — -1/2, not -1/1
+    assert m["total_pdiff"] == pytest.approx(-0.5)
+    assert m["abs_total_pdiff"] == pytest.approx(0.5)
+
+
+def test_compute_metrics_zero_reference_total_gives_zero_percentage():
+    # Given: an all-zero reference, so the percentage difference has no
+    #        denominator
+    pred = np.array([[1.0, 2.0]], dtype=np.float32)
+    val = np.zeros((1, 2), dtype=np.float32)
+
+    # When: compute_metrics scores the tile
+    m = compute_metrics(pred, val, np.zeros((1, 2)), np.ones((1, 2), dtype=bool))
+
+    # Then: the percentage difference is 0 rather than an infinity or a
+    #       ZeroDivisionError, while the absolute difference still reports
+    #       the 3 predictions that have no reference behind them
+    assert m["total_diff"] == pytest.approx(3.0)
+    assert m["total_pdiff"] == 0.0
+    assert m["abs_total_pdiff"] == 0.0
+
+
+def test_compute_metrics_empty_mask_returns_infinite_error_metrics():
+    # Given: a mask that excludes every cell of the tile
+    pred = np.ones((2, 2), dtype=np.float32)
+    val = np.zeros((2, 2), dtype=np.float32)
+
+    # When: compute_metrics scores it
+    m = compute_metrics(pred, val, np.zeros((2, 2)), np.zeros((2, 2), dtype=bool))
+
+    # Then: the error metrics are +inf rather than the NaN a mean over an
+    #       empty slice would give — a tile with nothing to score must never
+    #       compare as better than one that scored badly
+    assert m["n_cells"] == 0
+    assert m["rms"] == float("inf")
+    assert m["mae"] == float("inf")
+    assert m["rmsle"] == float("inf")
+    assert math.isnan(m["spearman"])
+
+
+def test_is_better_compares_in_each_metric_direction():
+    # Given: rms, which METRIC_DIRECTIONS minimizes, and spearman, the only
+    #        metric it maximizes
+    incumbent = 0.5
+
+    # When: a candidate below the incumbent is offered to each
+    # Then: it improves the minimized metric and not the maximized one
+    assert is_better("rms", 0.4, incumbent)
+    assert not is_better("spearman", 0.4, incumbent)
+
+    # When: a candidate above the incumbent is offered to each
+    # Then: the verdicts reverse. A scan tuned on spearman that compared in
+    #       the minimizing direction would export the worst correlation it
+    #       found rather than the best.
+    assert not is_better("rms", 0.6, incumbent)
+    assert is_better("spearman", 0.6, incumbent)
+
+
+def test_is_better_rejects_a_non_finite_candidate():
+    # Given: the sentinel each direction starts from, which any real
+    #        measurement beats
+    worst_for_min = float("inf")
+    worst_for_max = -float("inf")
+
+    # When: a NaN candidate is offered against those sentinels
+    # Then: neither direction accepts it. A tile that could not be scored
+    #       must never become the incumbent, and NaN compares false against
+    #       everything anyway — so without this guard the max branch would
+    #       depend on comparison order rather than rejecting outright.
+    assert not is_better("rms", float("nan"), worst_for_min)
+    assert not is_better("spearman", float("nan"), worst_for_max)
+
+    # When: an infinite candidate is offered in the direction that would
+    #       otherwise welcome it
+    # Then: it is rejected too — only finite measurements can win
+    assert not is_better("spearman", float("inf"), worst_for_max)
+
+
+def test_compute_metrics_constant_reference_leaves_spearman_undefined():
+    # Given: predictions that vary against a reference that is constant, so
+    #        the reference has no ranking to correlate against
+    pred = np.array([[1.0, 2.0, 3.0]], dtype=np.float32)
+    val = np.full((1, 3), 4.0, dtype=np.float32)
+
+    # When: compute_metrics scores the tile
+    m = compute_metrics(pred, val, np.zeros((1, 3)), np.ones((1, 3), dtype=bool))
+
+    # Then: spearman is NaN, while the error metrics stay finite — an
+    #       undefined correlation must not take the rest of the row with it
+    assert math.isnan(m["spearman"])
+    assert math.isfinite(m["rms"])
+    assert math.isfinite(m["mae"])


### PR DESCRIPTION
## Why

The 6-part test stack was merged bottom-up, but only half of it reached `Karim`. PRs #35, #41, #42 and #48 were merged into `Karim` directly — the rest were squash-merged into their **parent stack branch** instead, so their tests were left stranded on branches nobody merged down. They show as merged on GitHub, but their tests are not on `Karim`.

| PR | Test files | On `Karim` before this? |
|---|---|---|
| #35 (1/6) | `_helpers`, `conftest`, `test_thresholding`, `test_deduplication` | ✅ |
| #41 (2/6) | `test_merge_geojsons`, `test_merge_tuned` | ✅ |
| #42 (3/6) | `test_reference_data` | ✅ |
| #48 (4a/6) | `test_scan_orchestrator` | ✅ |
| #49 (4b/6) | `test_validation_core` | ❌ stranded |
| #43 (4c/6) | `test_scan_validation` + the `g1_scan_validation.py` seams it needs | ❌ stranded |
| #44 (5/6) | `test_config_flows`, `test_pipeline_runner` | ❌ stranded |
| #45 (6/6) | `test_add_new_model_results`, `test_annotation_reference`, `test_evaluation_common` | ❌ stranded |

## What this does

Merges `claude/tests-config-pipelines` — the stack tip that already carries all four missing PRs — so one merge recovers the whole remainder instead of four separate cherry-picks. `Karim` ends up with the complete 6-part suite.

**+2,630 lines**: 7 test files, plus the `g1_scan_validation.py` seam refactor that #43's tests depend on (the only non-test change, and it came with #43).

| New file | Tests |
|---|---|
| `tests/test_scan_validation.py` | 22 |
| `tests/test_evaluation_common.py` | 22 |
| `tests/test_config_flows.py` | 16 |
| `tests/test_annotation_reference.py` | 14 |
| `tests/test_pipeline_runner.py` | 13 |
| `tests/test_add_new_model_results.py` | 8 |
| `tests/test_validation_core.py` | 7 |
| | **102** |

## Conflicts: none

Two things could plausibly have collided, and neither did:

- **#48's tests are on `Karim` already.** It landed as a squash commit whose content is byte-identical to the stack's own version, so the add/add on `test_scan_orchestrator.py` resolved cleanly with no content change.
- **The dead-code purge in #40** landed on `Karim` *after* the stack branched, which was the real risk — tests written against since-deleted code. It doesn't touch `g1_scan_validation.py` or anything these tests exercise; nothing under `tests/` references the purged modules.

## Verification

Run against the merged tree, matching both gates in `ci.yml`:

- `pytest tests/` → **231 passed** (129 on `Karim` before, + the 102 above)
- `ruff check .` → clean
- `ruff format --check .` → 73 files already formatted

## Note for #47

#47 (ruff 0.16 upgrade) is open against `Karim` and will want a rebase over this — it now has ~2.8k more lines of test code in scope for the expanded rule set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPayeYHhRa4wBLB9qXW3wm)_