### PR TITLE
Fetch a pinned model release from the Hugging Face Hub

### DIFF
--- a/displacement_tracker/util/model_ref.py
+++ b/displacement_tracker/util/model_ref.py
@@ -1,33 +1,56 @@
 """Resolve a model reference to a local checkpoint file.
 
 A model reference is either a filesystem path — the historic behaviour, kept
-for local development checkpoints — or a release on the Hugging Face Hub::
+for local development checkpoints — or a pinned release on the Hugging Face
+Hub::
 
     hf:<owner>/<name>@<40-char-commit-sha>#<filename>
     https://huggingface.co/<owner>/<name>/blob/<sha>/<filename>
 
-Parsing is separated from resolving because it is a total, offline function:
-any string is either a Hub reference, a path, or a syntax error, and deciding
-which needs no filesystem and no network.
+Only a commit SHA pins. Branches and tags move, so a reference naming one is
+rejected with the SHA it currently points at, ready to paste back into the
+config.
 
-Only a commit SHA can pin a release — branches and tags move — but a
-reference is parsed whether or not it names one, so that resolution can
-report precisely which part is missing rather than failing on the syntax.
-
-Resolving a local path confirms the file is there and, when the config
-supplies a digest, that its contents are what was expected. Fetching a Hub
-release is not implemented here yet.
+The repository holding the weights is private, so every Hub call is
+authenticated with ``HF_TOKEN`` taken from the environment (``.env`` is loaded
+first, as elsewhere in this project). A private repository answers an
+unauthorised request with 404 rather than 401 — it will not confirm that it
+exists — so a bare "repository not found" is nearly always a missing or
+under-scoped token rather than a typo, and the error says so.
 """
 
 from __future__ import annotations
 
 import hashlib
+import os
 import re
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
 import click
+from dotenv import load_dotenv
+from huggingface_hub import HfApi, hf_hub_download
+from huggingface_hub import constants as hf_constants
+from huggingface_hub.errors import (
+    EntryNotFoundError,
+    GatedRepoError,
+    HfHubHTTPError,
+    LocalEntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
+
+# Not re-exported at package level in 1.x, but the module is public. Worth the
+# deeper import: _check_snapshot compares against the path this builds, so a
+# hand-rolled copy of the Hub's folder naming would fail every resolution the
+# day the Hub changed it.
+from huggingface_hub.file_download import repo_folder_name
+
+from displacement_tracker.util.logging_config import setup_logging
+
+LOGGER = setup_logging("model_ref")
 
 HF_SCHEME = "hf:"
 HF_HOSTS = frozenset({"huggingface.co", "www.huggingface.co"})
@@ -38,11 +61,13 @@ _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 _REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 _SYNTAX = "hf:<owner>/<name>@<40-char-commit-sha>#<filename>"
+_OWNER = "the TentNetFA repo owner"
+_WEIGHT_SUFFIXES = (".safetensors", ".pth", ".pt", ".bin")
 _HASH_CHUNK = 1024 * 1024
 
 
 class ModelRefError(click.ClickException):
-    """A model reference could not be parsed or resolved.
+    """A model reference could not be resolved.
 
     Subclasses ClickException so stage CLIs print the message rather than a
     traceback; the message is the user-facing explanation and always carries
@@ -54,8 +79,8 @@ class ModelRefError(click.ClickException):
 class HubRef:
     """A parsed Hugging Face Hub reference.
 
-    ``revision`` and ``filename`` are optional so that a partial reference
-    still parses, and whoever resolves it can say which part is missing.
+    ``revision`` and ``filename`` are optional at parse time so that
+    resolution can report precisely which part is missing.
     """
 
     repo_id: str
@@ -74,9 +99,8 @@ class HubRef:
 def parse_model_ref(ref: str | Path) -> HubRef | Path:
     """Parse ``ref`` into a :class:`HubRef` or a local :class:`Path`.
 
-    Performs no network or filesystem access. Only the ``hf:`` scheme and
-    Hugging Face URLs are treated as Hub references, so a local path is never
-    mistaken for one — including paths containing ``@`` or ``#``.
+    Performs no network access — a reference can be parsed offline; only
+    resolving it needs the Hub.
     """
     text = str(ref).strip()
     if not text:
@@ -90,53 +114,43 @@ def parse_model_ref(ref: str | Path) -> HubRef | Path:
     return Path(text).expanduser()
 
 
-def resolve_model_ref(ref: str | Path, *, sha256: str | None = None) -> Path:
+def resolve_model_ref(
+    ref: str | Path,
+    *,
+    sha256: str | None = None,
+    token: str | None = None,
+    cache_dir: str | Path | None = None,
+) -> Path:
     """Resolve ``ref`` to a readable local file.
 
-    ``sha256``, when given, is verified against the file's contents, so a
-    checkpoint that was truncated or swapped cannot be loaded silently.
+    Local paths are returned as-is once confirmed to exist. Hub references are
+    downloaded into the Hub cache (or reused from it, without touching the
+    network) and verified.
+
+    ``sha256``, when given, is checked on every resolution — including cache
+    hits — so a corrupted or swapped cached file cannot be loaded silently.
     """
     parsed = parse_model_ref(ref)
-    if isinstance(parsed, HubRef):
-        raise ModelRefError(
-            f"{parsed} names a Hugging Face release, which this build cannot "
-            "fetch yet. Point the config at a local checkpoint for now."
-        )
-    if not parsed.is_file():
-        raise ModelRefError(f"Model checkpoint not found: {parsed}")
-    _verify_digest(parsed, sha256)
-    return parsed
+    if isinstance(parsed, Path):
+        if not parsed.is_file():
+            raise ModelRefError(f"Model checkpoint not found: {parsed}")
+        _verify_digest(parsed, sha256)
+        return parsed
+
+    resolved_token = token if token is not None else _token_from_env()
+    if not parsed.revision or not _COMMIT_SHA.match(parsed.revision):
+        _raise_unpinned(parsed, resolved_token)
+    if not parsed.filename:
+        raise _missing_filename_error(parsed, resolved_token)
+
+    path = _download(parsed, resolved_token, cache_dir)
+    _check_snapshot(path, parsed, cache_dir)
+    _verify_digest(path, sha256, ref=parsed)
+    return path
 
 
-def _verify_digest(path: Path, expected: str | None) -> None:
-    """Check the file against an expected sha256, if one was configured."""
-    if not expected:
-        return
-    want = str(expected).strip().lower().removeprefix("sha256:")
-    if not _SHA256.fullmatch(want):
-        # Reached when YAML read an unquoted all-digit digest as a number, and
-        # for an ordinary typo. Reporting a checksum mismatch here would blame
-        # the checkpoint for a mistake in the config.
-        raise ModelRefError(
-            f"Expected sha256 is not a 64-character hex digest: {want}. If it was "
-            "written unquoted in config.yaml, YAML read it as a number — quote it."
-        )
-    got = _sha256(path)
-    if got == want:
-        return
-    raise ModelRefError(
-        f"Checksum mismatch for {path}: expected sha256 {want}, got {got}. The "
-        "file may be corrupt or the release may have been replaced. Delete it and "
-        "retry."
-    )
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(_HASH_CHUNK), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+# --------------------------------------------------------------------------
+# parsing
 
 
 def _is_hub_url(text: str) -> bool:
@@ -179,3 +193,224 @@ def _hub_ref(repo_id: str, revision: str, filename: str) -> HubRef:
     if re.fullmatch(r"[0-9a-fA-F]{40}", revision):
         revision = revision.lower()
     return HubRef(repo_id, revision or None, filename.strip() or None)
+
+
+def _token_from_env() -> str | None:
+    """Return ``HF_TOKEN`` from the environment, loading ``.env`` first."""
+    load_dotenv()
+    token = os.getenv("HF_TOKEN")
+    token = token.strip() if token else ""
+    return token or None
+
+
+# --------------------------------------------------------------------------
+# Hub access, with every failure mapped onto its actual cause
+
+
+def _auth(token: str | None) -> str | bool:
+    """Hub credential to send: the token, or an explicit "no credential".
+
+    ``token=None`` would let huggingface_hub fall back to a credential saved by
+    ``hf auth login``. HF_TOKEN is the single supported source, so say no
+    explicitly — otherwise a stored credential could quietly decide whether a
+    run works, and "no HF_TOKEN found" would be a lie.
+    """
+    return token or False
+
+
+@contextmanager
+def _hub_errors(repo_id: str, revision: str | None, token: str | None, what: str):
+    """Translate the Hub's HTTP failures into ModelRefError.
+
+    Covers every failure both metadata lookups and downloads can hit. The two
+    that only downloads produce — an absent file, and an offline cache miss —
+    are not HTTP errors and pass through to the caller that can describe them.
+    """
+    try:
+        yield
+    # GatedRepoError subclasses RepositoryNotFoundError, so it comes first.
+    except GatedRepoError as exc:
+        raise ModelRefError(
+            f"Access to '{repo_id}' is gated and has not been granted for this "
+            f"token. Ask {_OWNER} for access."
+        ) from exc
+    except RepositoryNotFoundError as exc:
+        raise _access_error(repo_id, token) from exc
+    except RevisionNotFoundError as exc:
+        # Reached for a mistyped branch name as well as an unknown commit, so
+        # this says "revision" rather than claiming it was a commit.
+        raise ModelRefError(f"'{repo_id}' has no revision '{revision}'.") from exc
+    except HfHubHTTPError as exc:
+        raise ModelRefError(
+            f"Hugging Face Hub error while {what}: {_scrub(exc, token)}"
+        ) from exc
+
+
+def _api_call(repo_id: str, revision: str, token: str | None):
+    """Fetch repo metadata."""
+    with _hub_errors(repo_id, revision, token, f"reading '{repo_id}'"):
+        return HfApi(token=_auth(token)).model_info(repo_id, revision=revision)
+
+
+def _download(ref: HubRef, token: str | None, cache_dir: str | Path | None) -> Path:
+    LOGGER.info(f"🔹 Resolving {ref} from the Hugging Face Hub.")
+    try:
+        with _hub_errors(ref.repo_id, ref.revision, token, f"downloading {ref}"):
+            return Path(
+                hf_hub_download(
+                    repo_id=ref.repo_id,
+                    filename=ref.filename,
+                    revision=ref.revision,
+                    token=_auth(token),
+                    cache_dir=cache_dir,
+                )
+            )
+    # LocalEntryNotFoundError subclasses EntryNotFoundError, so it comes first.
+    except LocalEntryNotFoundError as exc:
+        raise ModelRefError(
+            f"{ref} is not in the local Hugging Face cache and the Hub could not be "
+            f"reached. Expected at: {_expected_cache_path(ref, cache_dir)}. Run this "
+            "on a machine with network access to populate the cache, or copy that "
+            "file across."
+        ) from exc
+    except EntryNotFoundError as exc:
+        raise ModelRefError(
+            f"File '{ref.filename}' is not in '{ref.repo_id}' at commit "
+            f"{ref.revision}.{_available_files(ref, token)}"
+        ) from exc
+
+
+def _access_error(repo_id: str, token: str | None) -> ModelRefError:
+    """Turn a 404 into the reason it actually happened.
+
+    A private repository 404s rather than 403s, so "not found" on its own is
+    misleading. The distinction that changes what the user does is whether
+    they have a token at all: without one there is a local fix, with one the
+    token has to be replaced or granted access by its owner.
+    """
+    if not token:
+        return ModelRefError(
+            f"Cannot reach '{repo_id}': the repository is private and no HF_TOKEN was "
+            "found in the environment or .env. Add HF_TOKEN=<read token> to .env, or "
+            f"ask {_OWNER} for access if you do not have a token."
+        )
+    return ModelRefError(
+        f"HF_TOKEN is set but cannot read '{repo_id}' — a private repository answers "
+        "404 rather than 403, so the token is expired, revoked, or its repository "
+        f"scope does not cover this repo. Ask {_OWNER} for access."
+    )
+
+
+def _raise_unpinned(ref: HubRef, token: str | None) -> None:
+    """Reject a missing or movable revision, quoting the SHA to pin instead.
+
+    Always raises: either the Hub lookup fails, or the reference is unpinned
+    and that is itself the error.
+    """
+    lookup = ref.revision or "main"
+    info = _api_call(ref.repo_id, lookup, token)
+    sha = getattr(info, "sha", None) or "<unknown>"
+    pinned = HubRef(ref.repo_id, sha, ref.filename)
+    if not ref.revision:
+        raise ModelRefError(
+            f"{ref} names no revision, and only a commit SHA pins a release. "
+            f"'{lookup}' currently points at {sha} — pin it with: {pinned}"
+        )
+    raise ModelRefError(
+        f"'{ref.revision}' is a branch or tag, not a commit SHA. Branches and tags "
+        f"move, so they cannot pin a release; '{ref.revision}' currently points at "
+        f"{sha} — pin it with: {pinned}"
+    )
+
+
+def _missing_filename_error(ref: HubRef, token: str | None) -> ModelRefError:
+    return ModelRefError(
+        f"{ref} names no file. Append the checkpoint to load, e.g. "
+        f"{HubRef(ref.repo_id, ref.revision, 'best_model.safetensors')}."
+        f"{_available_files(ref, token)}"
+    )
+
+
+def _available_files(ref: HubRef, token: str | None) -> str:
+    """Best-effort listing of candidate weight files, for error messages.
+
+    Never raises: this decorates an error that has already been diagnosed, and
+    a second failure here must not mask the first.
+    """
+    try:
+        info = _api_call(ref.repo_id, ref.revision or "main", token)
+        names = [sibling.rfilename for sibling in getattr(info, "siblings", None) or []]
+    except Exception:
+        return ""
+    weights = [name for name in names if name.endswith(_WEIGHT_SUFFIXES)]
+    listed = weights or names
+    if not listed:
+        return ""
+    shown = ", ".join(sorted(listed)[:10])
+    return f" Available: {shown}."
+
+
+# --------------------------------------------------------------------------
+# verification
+
+
+def _check_snapshot(path: Path, ref: HubRef, cache_dir: str | Path | None) -> None:
+    """Confirm the Hub served the commit the reference pins.
+
+    The cache stores a download under ``snapshots/<sha>/<filename>``, so the
+    path a correct download lands on is fully determined by the reference.
+    Comparing against it fails closed: any path we cannot account for is
+    refused rather than accepted unchecked.
+    """
+    expected = _expected_cache_path(ref, cache_dir)
+    if path != expected:
+        raise ModelRefError(
+            f"Hub served {path} for {ref}, which pins commit {ref.revision} at "
+            f"{expected}. Refusing to load."
+        )
+
+
+def _verify_digest(path: Path, expected: str | None, ref: HubRef | None = None) -> None:
+    """Check the file against an expected sha256, if one was configured."""
+    if not expected:
+        return
+    want = str(expected).strip().lower().removeprefix("sha256:")
+    if not _SHA256.fullmatch(want):
+        # Reached when YAML read an unquoted all-digit digest as a number, and
+        # for an ordinary typo. Reporting a checksum mismatch here would blame
+        # the checkpoint for a mistake in the config.
+        raise ModelRefError(
+            f"Expected sha256 is not a 64-character hex digest: {want}. If it was "
+            "written unquoted in config.yaml, YAML read it as a number — quote it."
+        )
+    got = _sha256(path)
+    if got == want:
+        return
+    source = f"{ref} at {path}" if ref else str(path)
+    raise ModelRefError(
+        f"Checksum mismatch for {source}: expected sha256 {want}, got {got}. The "
+        "file may be corrupt or the release may have been replaced. Delete it and "
+        "retry."
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(_HASH_CHUNK), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _expected_cache_path(ref: HubRef, cache_dir: str | Path | None) -> Path:
+    root = Path(cache_dir or hf_constants.HF_HUB_CACHE)
+    folder = repo_folder_name(repo_id=ref.repo_id, repo_type="model")
+    return root / folder / "snapshots" / str(ref.revision) / str(ref.filename)
+
+
+def _scrub(value: object, token: str | None) -> str:
+    """Stringify Hub output with the token redacted, wherever it came from."""
+    text = str(value)
+    if token:
+        text = text.replace(token, "***")
+    return text

--- a/docs/test-patterns.md
+++ b/docs/test-patterns.md
@@ -151,6 +151,32 @@ reason about: a handful of points, a 3×3 grid, two dates.
 Passing a plain function or lambda where the code under test takes a callable
 is not mocking — that is the function's real parameter contract.
 
+### The network boundary
+
+One narrow exception, for code whose subject *is* a remote service:
+`displacement_tracker/util/model_ref.py` resolves a model reference against
+the Hugging Face Hub, and there is no offline equivalent of a private
+repository the way `tmp_path` is an offline equivalent of a file. The Hub
+client's entry points may therefore be stubbed, on the same reasoning as
+`load_dotenv`: a remote service is ambient environment, and a suite that
+reaches it would be neither deterministic nor runnable in CI.
+
+The carve-out is deliberately small:
+
+- **Stub the boundary, never the module under test.** Replace the Hub
+  client's entry points; `parse_model_ref`, `resolve_model_ref` and the
+  functions they call run for real.
+- **Drive behavior through it, don't assert traffic across it.** Make a stub
+  raise what the Hub would raise, then assert on the resulting error message
+  — the thing a user acts on. §1 still applies: "the mock was called with X"
+  is not a test, so pass-through parameters and zero-call counts stay out.
+- **One exception to that, for credentials.** Which credential is sent is a
+  security-relevant invariant that is only observable at this boundary:
+  sending `None` instead of `False` lets a credential saved by `hf auth
+  login` decide whether a run works, so `HF_TOKEN` would silently stop being
+  the single source. That assertion is allowed, and is the only call-record
+  assertion that is.
+
 ## 4. Derive expectations by hand
 
 Compute the expected value yourself from the definition of the behavior, on

--- a/poetry.lock
+++ b/poetry.lock
@@ -42,12 +42,24 @@ doc = ["docutils", "jinja2", "myst-parser", "numpydoc", "pillow", "pydata-sphinx
 save = ["vl-convert-python (>=1.9.0)"]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+description = "Document parameters, class attributes, return types, and variables inline, with Annotated."
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "test"]
+files = [
+    {file = "annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101"},
+    {file = "annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb"},
+]
+
+[[package]]
 name = "anyio"
 version = "4.14.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["ui"]
+groups = ["main", "test", "ui"]
 files = [
     {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
     {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
@@ -603,7 +615,7 @@ version = "3.24.3"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d"},
     {file = "filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa"},
@@ -736,7 +748,7 @@ version = "2026.2.0"
 description = "File-system specification"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "test"]
 files = [
     {file = "fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437"},
     {file = "fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff"},
@@ -941,11 +953,64 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "ui"]
+groups = ["main", "test", "ui"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.2"
+description = "Fast transfer of large files with the Hugging Face Hub."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "test"]
+markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+files = [
+    {file = "hf_xet-1.5.2-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:4a5ecb9cda8512ba2aa8ee5d37c87a1422992165892d653098c7b90247481c3b"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8764488197c1d7b1378c8438c18d2eea902e150dbca0b0f0d2d32603fb9b5576"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8d7446f72abbf7e01ca5ff131786bc2e74a56393462c17a6bf1e303fbab81db4"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:580e59e29bf37aece1f2b68537de1e3fb04f43a23d910dcf6f128280b5bfbba4"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bee28c619622d36968056532fd49cf2b35ca75099b1d616c31a618a893491380"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e396ab0faf6298199ad7a95305c3ca8498cb825978a6485be6d00587ee4ec577"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fd3add255549e8ef58fa35b2e42dc016961c050600444e7d77d030ba6b57120e"},
+    {file = "hf_xet-1.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d6f9c58549407b84b9a5383afd68db0acc42345326a3159990b36a5ca8a20e4e"},
+    {file = "hf_xet-1.5.2-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:f922b8f5fb84f1dd3d7ab7a1316354a1bca9b1c73ecfc19c76e51a2a49d29799"},
+    {file = "hf_xet-1.5.2-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:045f84440c55cdeb659cf1a1dd48c77bcd0d2e93632e2fea8f2c3bdee79f38ed"},
+    {file = "hf_xet-1.5.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:db78c39c83d6279daddc98e2238f373ab8980685556d42472b4ec51abcf03e8c"},
+    {file = "hf_xet-1.5.2-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7db73c810500c54c6760be8c39d4b2e476974de85424c50063efc22fdda13025"},
+    {file = "hf_xet-1.5.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6395cfe3c9cbead4f16b31808b0e67eac428b66c656f856e99636adaddea878f"},
+    {file = "hf_xet-1.5.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cde8cd167126bb6109b2ceb19b844433a4988643e8f3e01dd9dd0e4a34535097"},
+    {file = "hf_xet-1.5.2-cp38-abi3-win_amd64.whl", hash = "sha256:ecf63d1cb69a9a7319910f8f83fcf9b46e7a32dfcf4b8f8eeddb55f647306e65"},
+    {file = "hf_xet-1.5.2-cp38-abi3-win_arm64.whl", hash = "sha256:1da28519496eb7c8094c11e4d25509b4a468457a0302d58136099db2fd9a671d"},
+    {file = "hf_xet-1.5.2.tar.gz", hash = "sha256:73044bd31bae33c984af832d19c752a0dffb67518fee9ddbd91d616e1101cf47"},
+]
+
+[package.extras]
+tests = ["pytest"]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "test"]
+files = [
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.16"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httplib2"
@@ -1023,12 +1088,73 @@ files = [
 ]
 
 [[package]]
+name = "httpx"
+version = "0.28.1"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "test"]
+files = [
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+
+[package.extras]
+brotli = ["brotli ; platform_python_implementation == \"CPython\"", "brotlicffi ; platform_python_implementation != \"CPython\""]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
+optional = false
+python-versions = ">=3.10.0"
+groups = ["main", "test"]
+files = [
+    {file = "huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22"},
+    {file = "huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832"},
+]
+
+[package.dependencies]
+filelock = ">=3.10.0"
+fsspec = ">=2023.5.0"
+hf-xet = {version = ">=1.4.3,<2.0.0", markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""}
+httpx = ">=0.23.0,<1"
+packaging = ">=20.9"
+pyyaml = ">=5.1"
+tqdm = ">=4.42.1"
+typer = ">=0.20.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+all = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+dev = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "libcst (>=1.4.0)", "mypy (==1.15.0)", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "ruff (>=0.9.0)", "soundfile", "ty", "types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)", "urllib3 (<2.0)"]
+fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
+gradio = ["gradio (>=5.0.0)", "requests"]
+hf-xet = ["hf-xet (>=1.4.3,<2.0.0)"]
+mcp = ["mcp (>=1.8.0)"]
+oauth = ["authlib (>=1.3.2)", "fastapi", "httpx", "itsdangerous"]
+quality = ["libcst (>=1.4.0)", "mypy (==1.15.0)", "ruff (>=0.9.0)", "ty"]
+testing = ["Jinja2", "Pillow", "authlib (>=1.3.2)", "duckdb", "fastapi", "fastapi", "httpx", "itsdangerous", "jedi", "numpy", "pytest (>=8.4.2)", "pytest-asyncio", "pytest-cov", "pytest-env", "pytest-mock", "pytest-rerunfailures (<16.0)", "pytest-vcr", "pytest-xdist", "soundfile", "urllib3 (<2.0)"]
+torch = ["safetensors[torch]", "torch"]
+typing = ["types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3", "typing-extensions (>=4.8.0)"]
+
+[[package]]
 name = "idna"
 version = "3.11"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "ui"]
+groups = ["main", "dev", "test", "ui"]
 files = [
     {file = "idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea"},
     {file = "idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902"},
@@ -1240,6 +1366,30 @@ files = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+description = "Python port of markdown-it. Markdown parsing, done right!"
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "test"]
+files = [
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
+]
+
+[package.dependencies]
+mdurl = ">=0.1,<1.0"
+
+[package.extras]
+benchmarking = ["psutil", "pytest", "pytest-benchmark"]
+compare = ["commonmark (>=0.9,<1.0)", "markdown (>=3.4,<4.0)", "markdown-it-pyrs", "mistletoe (>=1.0,<2.0)", "mistune (>=3.0,<4.0)", "panflute (>=2.3,<3.0)"]
+linkify = ["linkify-it-py (>=1,<3)"]
+plugins = ["mdit-py-plugins (>=0.5.0)"]
+profiling = ["gprof2dot"]
+rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1416,6 +1566,18 @@ python-dateutil = ">=2.7"
 
 [package.extras]
 dev = ["meson-python (>=0.13.1,<0.17.0)", "pybind11 (>=2.13.2,!=2.13.3)", "setuptools (>=64)", "setuptools_scm (>=7)"]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+description = "Markdown URL utilities"
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "test"]
+files = [
+    {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
+    {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
 
 [[package]]
 name = "mpmath"
@@ -2344,7 +2506,7 @@ version = "2.20.0"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "test"]
+groups = ["main", "dev", "test"]
 files = [
     {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
     {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
@@ -2849,6 +3011,25 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+optional = false
+python-versions = ">=3.9.0"
+groups = ["main", "test"]
+files = [
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=2.2.0"
+pygments = ">=2.13.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
 name = "rpds-py"
@@ -3447,6 +3628,18 @@ docs = ["matplotlib", "numpydoc (==1.1.*)", "sphinx", "sphinx-book-theme", "sphi
 test = ["pytest", "pytest-cov", "scipy-doctest"]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+description = "Tool to Detect Surrounding Shell"
+optional = false
+python-versions = ">=3.7"
+groups = ["main", "test"]
+files = [
+    {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
+    {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -3903,6 +4096,24 @@ tests = ["autopep8", "isort", "llnl-hatchet", "numpy", "pytest", "pytest-forked"
 tutorials = ["matplotlib", "pandas", "tabulate"]
 
 [[package]]
+name = "typer"
+version = "0.27.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+optional = false
+python-versions = ">=3.10"
+groups = ["main", "test"]
+files = [
+    {file = "typer-0.27.0-py3-none-any.whl", hash = "sha256:6f4b27631e47f077871b7dc30e933ec0131c1390fbe0e387ea5574b5bac9ccf1"},
+    {file = "typer-0.27.0.tar.gz", hash = "sha256:629bd12ea5d13a17148125d9a264f949eb171fb3f120f9b04d85873cab054fa5"},
+]
+
+[package.dependencies]
+annotated-doc = ">=0.0.2"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+rich = ">=13.8.0"
+shellingham = ">=1.3.0"
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -3913,7 +4124,7 @@ files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
 ]
-markers = {dev = "python_version == \"3.10\"", test = "python_version == \"3.10\""}
+markers = {dev = "python_version == \"3.10\""}
 
 [[package]]
 name = "tzdata"
@@ -4218,4 +4429,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10,<3.15"
-content-hash = "23898313afb0575a30a8e6d7b6a5e99e7fe6701a44d0806f58ad54a0f935e6d6"
+content-hash = "a83ceb8064a19e387011e533f9b41495a5be11eb14ec115c3d71cec6de754a2e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ google-api-python-client = "^2.176.0"
 scipy = "1.15.3"
 pyarrow = "^17.0.0"
 PyYAML = "^6.0.1"
+huggingface-hub = "^1.0"
 
 # --- GIS libraries ---
 # Both ship prebuilt wheels for every platform we target, including Apple
@@ -90,6 +91,7 @@ test = [
     "click",
     "fiona",
     "geopandas",
+    "huggingface-hub",
     "matplotlib",
     "numpy",
     "pandas",

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -1,16 +1,32 @@
-"""Tests for displacement_tracker.util.model_ref: parsing a model reference
-into the Hub release or local checkpoint it names, and resolving a local one
-to a verified file.
+"""Tests for displacement_tracker.util.model_ref: parsing a model reference,
+resolving a local checkpoint, and fetching a pinned Hugging Face release.
 
 Parsing needs no network, and resolving a local checkpoint needs only real
-files in tmp_path, so nothing here is stubbed.
+files in tmp_path. The Hub client's entry points are stubbed under the
+network-boundary carve-out in ``docs/test-patterns.md`` §3: the stubs raise
+what the Hub would raise, and the assertions are on the resulting behaviour —
+the error a user acts on, or the file that comes back — never on the traffic
+itself. The one exception the doc allows is the credential actually sent,
+which is only observable here and has a security consequence.
+
+The stubs live in this file rather than ``_helpers.py`` because it is their
+only consumer, and they encode no on-disk format.
 """
 
 import hashlib
 from pathlib import Path
 
 import pytest
+from huggingface_hub.errors import (
+    EntryNotFoundError,
+    GatedRepoError,
+    HfHubHTTPError,
+    LocalEntryNotFoundError,
+    RepositoryNotFoundError,
+    RevisionNotFoundError,
+)
 
+from displacement_tracker.util import model_ref
 from displacement_tracker.util.model_ref import (
     HubRef,
     ModelRefError,
@@ -19,9 +35,104 @@ from displacement_tracker.util.model_ref import (
 )
 
 SHA = "a" * 40
+OTHER_SHA = "b" * 40
 REPO = "realgoodresearch/tentnetfa"
 FILE = "best_model.safetensors"
 REF = f"hf:{REPO}@{SHA}#{FILE}"
+
+# Must never appear in anything a user sees.
+SENTINEL_TOKEN = "hf_sentineltokenvalue0123456789"
+
+
+# ---------------------------------------------------------------------------
+# Hub stubs
+# ---------------------------------------------------------------------------
+
+
+class StubResponse:
+    """The few response fields huggingface_hub's HTTP errors read.
+
+    Building these errors needs a response object. A stub keeps the suite off
+    whichever HTTP client huggingface_hub happens to use this major version.
+    """
+
+    def __init__(self, status):
+        self.status_code = status
+        self.headers = {}
+        self.text = ""
+        self.request = type("StubRequest", (), {"method": "GET", "url": ""})()
+
+
+def hub_error(cls, message, status=404):
+    """Build a huggingface_hub HTTP error as the Hub would raise it."""
+    return cls(message, response=StubResponse(status))
+
+
+class FakeInfo:
+    """Stands in for the ModelInfo returned by HfApi.model_info."""
+
+    def __init__(self, sha=SHA, filenames=(FILE,)):
+        self.sha = sha
+        self.siblings = [
+            type("Sibling", (), {"rfilename": name})() for name in filenames
+        ]
+
+
+class Calls:
+    """Records what crossed the Hub boundary.
+
+    Only the credential fields are asserted on; the rest exist so a stub can
+    answer a call at all.
+    """
+
+    def __init__(self):
+        self.api_tokens = []
+        self.download_tokens = []
+
+
+def stub_hub(
+    monkeypatch,
+    *,
+    info=None,
+    info_error=None,
+    download=None,
+    download_error=None,
+):
+    """Replace the Hub client's entry points; return the credential record.
+
+    Also neutralises dotenv loading and HF_TOKEN, so a developer's real .env
+    cannot decide the outcome of a test that asserts on the no-token path.
+    """
+    calls = Calls()
+
+    class FakeApi:
+        def __init__(self, token=None):
+            calls.api_tokens.append(token)
+
+        def model_info(self, repo_id, revision=None):
+            if info_error is not None:
+                raise info_error
+            return info if info is not None else FakeInfo()
+
+    def fake_download(*, token=None, **kwargs):
+        calls.download_tokens.append(token)
+        if download_error is not None:
+            raise download_error
+        return download
+
+    monkeypatch.setattr(model_ref, "load_dotenv", lambda *a, **k: False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setattr(model_ref, "HfApi", FakeApi)
+    monkeypatch.setattr(model_ref, "hf_hub_download", fake_download)
+    return calls
+
+
+def write_cached_file(root, sha=SHA, name=FILE, content=b"weights"):
+    """Write a file where the Hub cache would put it, and return its path."""
+    path = root / f"models--{REPO.replace('/', '--')}" / "snapshots" / sha / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -180,15 +291,6 @@ def test_a_missing_local_checkpoint_is_reported(tmp_path):
         resolve_model_ref(str(tmp_path / "absent.pth"))
 
 
-def test_a_hub_reference_is_refused_until_fetching_exists():
-    # Given: a fully pinned Hub reference, which this build cannot fetch
-    # When: it is resolved
-    # Then: it says so plainly instead of failing as a missing file — the
-    #       reference is well formed, the capability is what is absent
-    with pytest.raises(ModelRefError, match="cannot fetch yet"):
-        resolve_model_ref(REF)
-
-
 def test_a_local_checkpoint_digest_is_verified(tmp_path):
     # Given: a checkpoint and the sha256 of its contents
     path = tmp_path / "best_model.pth"
@@ -217,3 +319,293 @@ def test_a_malformed_expected_digest_is_reported_as_malformed(tmp_path):
     #       produces a non-string.)
     with pytest.raises(ModelRefError, match="not a 64-character hex digest"):
         resolve_model_ref(str(path), sha256="0" * 63)
+
+
+# ---------------------------------------------------------------------------
+# Pinning: only a commit SHA pins
+# ---------------------------------------------------------------------------
+
+
+def test_a_branch_is_rejected_with_the_sha_to_pin(monkeypatch):
+    # Given: a reference naming a branch, which can move, and a Hub where
+    #        that branch points at a known commit
+    stub_hub(monkeypatch, info=FakeInfo(sha=SHA))
+
+    # When: it is resolved
+    # Then: it is refused, and the message carries the commit the branch
+    #       points at, formatted ready to paste back into the config
+    with pytest.raises(ModelRefError, match=f"branch or tag.*hf:{REPO}@{SHA}#{FILE}"):
+        resolve_model_ref(f"hf:{REPO}@main#{FILE}")
+
+
+def test_a_missing_revision_is_rejected_with_the_sha_to_pin(monkeypatch):
+    # Given: a reference with no revision at all
+    stub_hub(monkeypatch, info=FakeInfo(sha=SHA))
+
+    # When: it is resolved
+    # Then: it is refused rather than silently defaulting to main, and says
+    #       what main currently points at
+    with pytest.raises(
+        ModelRefError, match=f"names no revision.*hf:{REPO}@{SHA}#{FILE}"
+    ):
+        resolve_model_ref(f"hf:{REPO}#{FILE}")
+
+
+def test_a_missing_filename_is_rejected_with_the_candidates(monkeypatch):
+    # Given: a pinned reference that names no file, in a repo holding
+    #        weights alongside other artifacts
+    stub_hub(
+        monkeypatch,
+        info=FakeInfo(filenames=(FILE, "training_log.csv", "old_model.pth")),
+    )
+
+    # When: it is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(f"hf:{REPO}@{SHA}")
+
+    # Then: the message lists the weight files to choose from, and leaves out
+    #       everything that could not be a checkpoint
+    message = str(err.value)
+    assert "names no file" in message
+    assert FILE in message
+    assert "old_model.pth" in message
+    assert "training_log.csv" not in message
+
+
+# ---------------------------------------------------------------------------
+# Download and verification
+# ---------------------------------------------------------------------------
+
+
+def test_a_pinned_reference_resolves_to_the_cached_file(monkeypatch, tmp_path):
+    # Given: a pinned reference whose file is in the cache
+    path = write_cached_file(tmp_path)
+    stub_hub(monkeypatch, download=str(path))
+
+    # When: it is resolved
+    # Then: that file comes back
+    assert resolve_model_ref(REF, cache_dir=tmp_path) == path
+
+
+def test_a_file_below_the_repository_root_resolves(monkeypatch, tmp_path):
+    # Given: a reference to a file nested inside the repository, in a
+    #        directory that happens to be called "snapshots" — the cache
+    #        layout then contains that word twice
+    nested = "weights/snapshots/best.safetensors"
+    path = write_cached_file(tmp_path, name=nested)
+    stub_hub(monkeypatch, download=str(path))
+
+    # When: it is resolved
+    # Then: it resolves, rather than mistaking part of the filename for the
+    #       commit the cache recorded
+    assert resolve_model_ref(f"hf:{REPO}@{SHA}#{nested}", cache_dir=tmp_path) == path
+
+
+def test_a_file_served_from_another_commit_is_refused(monkeypatch, tmp_path):
+    # Given: a cache entry recording a commit other than the pinned one
+    served = write_cached_file(tmp_path, sha=OTHER_SHA)
+    stub_hub(monkeypatch, download=str(served))
+
+    # When: the pinned reference is resolved
+    # Then: it refuses, naming the commit it was handed and the one it pins
+    with pytest.raises(ModelRefError, match=f"{OTHER_SHA}.*pins commit {SHA}"):
+        resolve_model_ref(REF, cache_dir=tmp_path)
+
+
+def test_a_file_from_outside_the_cache_layout_is_refused(monkeypatch, tmp_path):
+    # Given: a served path that does not match the cache layout at all
+    stray = tmp_path / "somewhere-else" / FILE
+    stray.parent.mkdir(parents=True)
+    stray.write_bytes(b"weights")
+    stub_hub(monkeypatch, download=str(stray))
+
+    # When: the pinned reference is resolved
+    # Then: it is refused rather than accepted unchecked — an unrecognised
+    #       layout fails closed
+    with pytest.raises(ModelRefError, match="Refusing to load"):
+        resolve_model_ref(REF, cache_dir=tmp_path)
+
+
+def test_a_downloaded_digest_is_verified(monkeypatch, tmp_path):
+    # Given: a pinned reference whose contents are known
+    path = write_cached_file(tmp_path, content=b"weights")
+    stub_hub(monkeypatch, download=str(path))
+    digest = hashlib.sha256(b"weights").hexdigest()
+
+    # When: it is resolved with the matching digest
+    # Then: it resolves
+    assert resolve_model_ref(REF, sha256=digest, cache_dir=tmp_path) == path
+
+    # When: it is resolved with a digest that does not match
+    # Then: it raises — the check runs on cache hits too, so a swapped or
+    #       corrupted cached file cannot load silently
+    with pytest.raises(ModelRefError, match="Checksum mismatch"):
+        resolve_model_ref(REF, sha256="0" * 64, cache_dir=tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Credentials
+#
+# Which credential is sent is the one call-record assertion docs/
+# test-patterns.md §3 allows: it is only observable at this boundary, and
+# getting it wrong silently widens where credentials come from.
+# ---------------------------------------------------------------------------
+
+
+def test_stored_hub_credentials_are_not_used(monkeypatch):
+    # Given: no HF_TOKEN, and a reference that forces a Hub call
+    calls = stub_hub(monkeypatch, info=FakeInfo(sha=SHA))
+
+    # When: it is resolved
+    with pytest.raises(ModelRefError):
+        resolve_model_ref(f"hf:{REPO}@main#{FILE}")
+
+    # Then: the Hub was told to send no credential at all. Passing None would
+    #       let it fall back to a token saved by `hf auth login`, so HF_TOKEN
+    #       would quietly stop being the single source.
+    assert calls.api_tokens == [False]
+
+
+def test_the_token_is_read_from_the_environment(monkeypatch, tmp_path):
+    # Given: HF_TOKEN set in the environment, padded with whitespace
+    calls = stub_hub(monkeypatch, download=str(write_cached_file(tmp_path)))
+    monkeypatch.setenv("HF_TOKEN", f"  {SENTINEL_TOKEN}  ")
+
+    # When: a reference is resolved without an explicit token
+    resolve_model_ref(REF, cache_dir=tmp_path)
+
+    # Then: the environment's token is what reaches the Hub, trimmed
+    assert calls.download_tokens == [SENTINEL_TOKEN]
+
+
+# ---------------------------------------------------------------------------
+# Failure diagnosis: a private repository answers 404, not 401
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_token_is_named_as_the_cause(monkeypatch):
+    # Given: no HF_TOKEN, and a Hub that reports the private repo as absent
+    stub_hub(
+        monkeypatch, download_error=hub_error(RepositoryNotFoundError, "404 not found")
+    )
+
+    # When: a pinned reference is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(REF)
+
+    # Then: the message says the repository is private and no token was
+    #       found, rather than "repository not found" — which reads as a typo
+    #       in the repo name
+    message = str(err.value)
+    assert "private" in message
+    assert "HF_TOKEN" in message
+
+
+def test_a_token_that_cannot_read_the_repository_is_named_as_the_cause(monkeypatch):
+    # Given: an HF_TOKEN that is set, and the same 404 the Hub returns
+    #        whether the token is expired or merely unscoped
+    stub_hub(
+        monkeypatch, download_error=hub_error(RepositoryNotFoundError, "404 not found")
+    )
+
+    # When: a pinned reference is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+    # Then: the message distinguishes this from a missing token and names
+    #       both remedies, since 404 cannot tell them apart
+    message = str(err.value)
+    assert "HF_TOKEN is set but cannot read" in message
+    assert "expired" in message
+
+
+def test_a_gated_repository_is_named_as_the_cause(monkeypatch):
+    # Given: a repository whose access is gated
+    stub_hub(monkeypatch, download_error=hub_error(GatedRepoError, "403 gated", 403))
+
+    # When: a pinned reference is resolved
+    # Then: the message says so, rather than blaming the token
+    with pytest.raises(ModelRefError, match="gated"):
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+
+def test_an_unknown_revision_is_named_as_the_cause(monkeypatch):
+    # Given: a repository that does not contain the pinned revision
+    stub_hub(
+        monkeypatch, download_error=hub_error(RevisionNotFoundError, "404 revision")
+    )
+
+    # When: the reference is resolved
+    # Then: the message names the revision that is missing
+    with pytest.raises(ModelRefError, match=f"has no revision '{SHA}'"):
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+
+def test_a_missing_file_lists_what_the_commit_holds(monkeypatch):
+    # Given: a commit that exists but does not hold the named file
+    stub_hub(
+        monkeypatch,
+        download_error=EntryNotFoundError("404 entry"),
+        info=FakeInfo(filenames=("other_model.safetensors",)),
+    )
+
+    # When: the reference is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+    # Then: the message names the missing file and what is there instead
+    message = str(err.value)
+    assert f"'{FILE}' is not in" in message
+    assert "other_model.safetensors" in message
+
+
+def test_a_failed_file_listing_does_not_mask_the_real_error(monkeypatch):
+    # Given: a missing file, and a repository listing that also fails
+    stub_hub(
+        monkeypatch,
+        download_error=EntryNotFoundError("404 entry"),
+        info_error=hub_error(RepositoryNotFoundError, "404 not found"),
+    )
+
+    # When: the reference is resolved
+    # Then: the original diagnosis survives — decorating an error must not
+    #       replace it
+    with pytest.raises(ModelRefError, match=f"'{FILE}' is not in"):
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+
+def test_an_offline_cache_miss_names_the_expected_path(monkeypatch, tmp_path):
+    # Given: no network, and nothing in the cache
+    stub_hub(monkeypatch, download_error=LocalEntryNotFoundError("offline"))
+
+    # When: a pinned reference is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(REF, token=SENTINEL_TOKEN, cache_dir=tmp_path)
+
+    # Then: the message says where the file was expected, so it can be
+    #       fetched or copied there from a networked machine
+    message = str(err.value)
+    assert "could not be reached" in message
+    expected = (
+        tmp_path / f"models--{REPO.replace('/', '--')}" / "snapshots" / SHA / FILE
+    )
+    assert str(expected) in message
+
+
+def test_the_token_is_scrubbed_from_hub_error_text(monkeypatch):
+    # Given: a Hub error whose text quotes the token back
+    stub_hub(
+        monkeypatch,
+        download_error=hub_error(
+            HfHubHTTPError, f"500 with token {SENTINEL_TOKEN} inside", 500
+        ),
+    )
+
+    # When: a reference is resolved
+    with pytest.raises(ModelRefError) as err:
+        resolve_model_ref(REF, token=SENTINEL_TOKEN)
+
+    # Then: the token is redacted from what the user sees
+    message = str(err.value)
+    assert SENTINEL_TOKEN not in message
+    assert "***" in message


### PR DESCRIPTION
**Third of three stacked PRs.** Base is #58 (local resolution), which bases on #57 (parsing). Review this one last — its diff is only the Hub layer.

- #57 — parsing. *343 lines, no new dependencies.*
- #58 — local resolution. *163 lines, no new dependencies.*
- **#52 (this) — Hub fetching.** *943 lines, of which 227 is generated lockfile.*

## What

Replaces the placeholder that refused Hub references with the fetch itself: a pinned reference resolves to a file in the Hub cache, verified against what was pinned.

```
hf:<owner>/<name>@<40-char-commit-sha>#<filename>
```

**Nothing is wired into the pipeline yet.** `e_predict_json` and `d_train_cnn` load exactly as they do today, so this changes no runtime behaviour.

## Design notes

**Only a commit SHA pins.** Branches and tags move, so a reference naming one is rejected with the SHA it currently points at, formatted ready to paste back into the config. Naming no revision is the same error, not an implicit `main`.

**The repository is private, which shapes the errors.** A private repo answers an unauthorised request with `404`, not `401` — it will not confirm that it exists — so a bare "repository not found" is nearly always a missing or under-scoped token rather than a typo. Every failure is diagnosed before it surfaces: no token, a token that cannot read the repo, a gated repo, an unknown revision, a missing file, an offline cache miss.

**`HF_TOKEN` from the environment is the single credential source.** The Hub is explicitly told not to fall back to a credential saved by `hf auth login` (`token=False` rather than `None`), so the no-token diagnosis cannot be wrong. The token is scrubbed from any Hub output that reaches a message.

**Integrity fails closed.** The resolved path is compared against the cache location the reference determines, so a file served from another commit — or from a layout we cannot account for — is refused rather than loaded.

Caching, atomic writes, retries and offline mode come from `huggingface_hub` rather than being re-implemented here.

## The test-conventions carve-out

`docs/test-patterns.md` §3 forbids stubbing the code under test. This module's subject *is* a remote service, and there is no offline equivalent of a private repository the way `tmp_path` is an offline equivalent of a file — so the suite cannot exist without stubbing that boundary.

The doc gains a narrow carve-out: stub the boundary, drive behaviour through it, don't assert traffic across it, with one named exception for the credential actually sent (a security-relevant invariant observable nowhere else). Assertions outside that carve-out were removed rather than grandfathered.

## Testing

18 Hub tests here, on top of the 22 in #57 and 8 in #58. No network, no `HF_TOKEN`, no Hub account. Verified against `huggingface-hub` 1.16.1, the version `poetry.lock` resolves.

`ruff check .`, `ruff format --check .`, `poetry check --lock` and the full 283-test suite pass.

## Dependencies

`huggingface-hub ^1.0`, in the project dependencies and the `test` group. Its transitive deps `filelock` and `fsspec` were already locked.

## Review history

This PR carries the three-round thermo-nuclear review that produced the current shape — six findings in round 1, two in round 2, approval in round 3 — including two real defects it caught: a nested-filename bug in the integrity check, and an unquoted-YAML digest crashing with `AttributeError`. The module is byte-identical to the approved state; the only change is one parsing test strengthened in #57.