### PR TITLE
Config hygiene: pool keys move to predict, `exclusion_zones` is inverted

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,9 @@
 # the flow matching the selected pipeline automatically.
 
 shared:
-  # Municipal boundaries; tiles outside them are skipped by every scan stage.
+  # Municipal boundaries. The training scan crops each source raster to them
+  # before tiling; the prediction flow tiles the whole raster and drops
+  # out-of-boundary points when the predictions are written.
   boundaries: gaza_boundaries/GazaStrip_MunicipalBoundaries.shp
   # Pre-war reference raster paired with every tile by every scan stage.
   prewar_gaza: ${DATA_DIR}/data/prewar_gaza.tif
@@ -38,9 +40,6 @@ train:
   # loading:
   #   files:  # optional filename filters / Drive search strings; empty = all
   processing:
-    max_workers: 8
-    max_tasks_per_child: 16
-    max_pool_restarts: 10
     quality_thresholds:
       min_valid_fraction: 0.9
     complete:
@@ -103,6 +102,11 @@ predict:
       # - "rafah_rafah_crossing_khan_yunis_20260220_123000_ssc10_u0003_visual_clip.tif"
       # - "tel_al_sultan_20260220_122923_ssc10_u0004_visual_clip.tif"
   processing:
+    # Worker pool for the prediction scan (b2_image_scanner); the training
+    # scan is serial and reads none of these.
+    max_workers: 8
+    max_tasks_per_child: 16
+    max_pool_restarts: 10
     quality_thresholds:
       min_valid_fraction: 0.1
   prediction:
@@ -197,7 +201,7 @@ tune:
     xtol_factor: 1.0e-3
     xtol_cutoff: 1.0e-6
     refine_maxiter: 60
-    exclusion_zones: null     # optional gpkg; predictions are clipped to its union
+    inclusion_zones: null     # optional gpkg; predictions are clipped to its union
     out_dir: ${DATA_DIR}/results/TentNetFA/model_beta2.0/2026-02/tuning
     best_params: ${DATA_DIR}/results/TentNetFA/model_beta2.0/2026-02/tuning/best_params.yaml
     final_output: ${DATA_DIR}/results/TentNetFA/model_beta2.0/2026-02/merged/merged_tuned.gpkg

--- a/displacement_tracker/g1_scan_validation.py
+++ b/displacement_tracker/g1_scan_validation.py
@@ -58,6 +58,7 @@ from displacement_tracker.util.validation_core import (
     process_grouped_cells,
     write_output_rasters,
 )
+from displacement_tracker.util.zones import load_zone_geometry
 
 SCAN_METRICS_DEFAULT = ("rms", "mae", "abs_total_diff")
 LARGE_PENALTY = 1e12
@@ -376,8 +377,9 @@ class ScanSettings:
                 "tuning.exclusion_zones has been renamed to "
                 "tuning.inclusion_zones: the zones are the area predictions "
                 "are clipped *to*, not dropped inside. Rename the key in your "
-                "config (merge.exclusion_zones_gpkg is unrelated and keeps "
-                "its name)."
+                "config, or delete it if it is unset — archived run configs "
+                "carry it as null. (merge.exclusion_zones_gpkg is unrelated "
+                "and keeps its name.)"
             )
 
         input_path = require(params, "tuning.input", "merge.output")
@@ -429,10 +431,12 @@ def prediction_date(settings: ScanSettings):
 
 
 def _load_predictions(settings: ScanSettings, raster_crs) -> gpd.GeoDataFrame:
-    """Read the merged raw predictions, optionally clipped to the scan zones."""
+    """Read the merged raw predictions, optionally clipped to the inclusion zones."""
     pred_gdf = gpd.read_file(settings.input_path).to_crs(raster_crs)
-    if settings.inclusion_zones:
-        inclusion_geom = gpd.read_file(settings.inclusion_zones).geometry.union_all()
+    inclusion_geom = load_zone_geometry(
+        settings.inclusion_zones, "inclusion", raster_crs
+    )
+    if inclusion_geom is not None:
         pred_gdf = pred_gdf.clip(inclusion_geom)
     if pred_gdf.empty:
         raise click.ClickException(

--- a/displacement_tracker/g1_scan_validation.py
+++ b/displacement_tracker/g1_scan_validation.py
@@ -359,7 +359,7 @@ class ScanSettings:
     xtol_factor: float
     xtol_cutoff: float
     refine_maxiter: int
-    exclusion_zones: str | None
+    inclusion_zones: str | None  # predictions are clipped to this union
 
     @property
     def base_name(self) -> str:
@@ -370,6 +370,15 @@ class ScanSettings:
         """Extract and validate the scan settings from a resolved (flat) config."""
         tuning = params.get("tuning") or {}
         merge_cfg = params.get("merge") or {}
+
+        if "exclusion_zones" in tuning:
+            raise click.ClickException(
+                "tuning.exclusion_zones has been renamed to "
+                "tuning.inclusion_zones: the zones are the area predictions "
+                "are clipped *to*, not dropped inside. Rename the key in your "
+                "config (merge.exclusion_zones_gpkg is unrelated and keeps "
+                "its name)."
+            )
 
         input_path = require(params, "tuning.input", "merge.output")
         out_dir = tuning.get("out_dir") or "scan_results"
@@ -404,7 +413,7 @@ class ScanSettings:
             xtol_factor=float(tuning.get("xtol_factor", 1e-3)),
             xtol_cutoff=float(tuning.get("xtol_cutoff", 1e-6)),
             refine_maxiter=int(tuning.get("refine_maxiter", 60)),
-            exclusion_zones=tuning.get("exclusion_zones"),
+            inclusion_zones=tuning.get("inclusion_zones"),
         )
 
 
@@ -422,9 +431,9 @@ def prediction_date(settings: ScanSettings):
 def _load_predictions(settings: ScanSettings, raster_crs) -> gpd.GeoDataFrame:
     """Read the merged raw predictions, optionally clipped to the scan zones."""
     pred_gdf = gpd.read_file(settings.input_path).to_crs(raster_crs)
-    if settings.exclusion_zones:
-        exclusion_geom = gpd.read_file(settings.exclusion_zones).geometry.union_all()
-        pred_gdf = pred_gdf.clip(exclusion_geom)
+    if settings.inclusion_zones:
+        inclusion_geom = gpd.read_file(settings.inclusion_zones).geometry.union_all()
+        pred_gdf = pred_gdf.clip(inclusion_geom)
     if pred_gdf.empty:
         raise click.ClickException(
             f"No predictions left to scan in {settings.input_path}"

--- a/displacement_tracker/g2_validate_geojson.py
+++ b/displacement_tracker/g2_validate_geojson.py
@@ -31,6 +31,7 @@ from displacement_tracker.util.validation_core import (
     process_grouped_cells,
     write_output_rasters,
 )
+from displacement_tracker.util.zones import load_zone_geometry
 
 
 def validate_one_tile(
@@ -150,14 +151,13 @@ def cli(
         nearest_to=infer_target_date(pred_paths),
     )
 
-    inclusion_geom = None
-    if inclusion_zones:
-        inclusion_geom = gpd.read_file(inclusion_zones).geometry.union_all()
-
     results = []
 
     with rasterio.open(master_grid) as src_grid:
         raster_crs = src_grid.crs
+        # Loaded here, not before the open: the zones have to be reprojected
+        # onto the grid CRS the predictions are clipped in.
+        inclusion_geom = load_zone_geometry(inclusion_zones, "inclusion", raster_crs)
 
         for pred_path in pred_paths:
             pred_file = os.path.basename(pred_path)

--- a/displacement_tracker/g2_validate_geojson.py
+++ b/displacement_tracker/g2_validate_geojson.py
@@ -99,10 +99,11 @@ def validate_one_tile(
 @click.option("--master-grid", type=click.Path(exists=True), required=True)
 @click.option("--out-dir", type=click.Path(), default="validation_results")
 @click.option(
-    "--exclusion-zones",
+    "--inclusion-zones",
     type=click.Path(exists=True),
     default=None,
-    help="Optional gpkg file of exclusion zones; predictions are clipped to its union.",
+    help="Optional gpkg file of inclusion zones; predictions are clipped to "
+    "its union, i.e. only points inside it are kept.",
 )
 @click.option(
     "--factor",
@@ -127,7 +128,7 @@ def cli(
     reference_where,
     master_grid,
     out_dir,
-    exclusion_zones,
+    inclusion_zones,
     factor,
     cutoff,
 ):
@@ -149,9 +150,9 @@ def cli(
         nearest_to=infer_target_date(pred_paths),
     )
 
-    exclusion_geom = None
-    if exclusion_zones:
-        exclusion_geom = gpd.read_file(exclusion_zones).geometry.union_all()
+    inclusion_geom = None
+    if inclusion_zones:
+        inclusion_geom = gpd.read_file(inclusion_zones).geometry.union_all()
 
     results = []
 
@@ -163,8 +164,8 @@ def cli(
             base_name = os.path.splitext(pred_file)[0]
 
             pred_gdf = gpd.read_file(pred_path).to_crs(raster_crs)
-            if exclusion_geom is not None:
-                pred_gdf = pred_gdf.clip(exclusion_geom)
+            if inclusion_geom is not None:
+                pred_gdf = pred_gdf.clip(inclusion_geom)
             if pred_gdf.empty:
                 continue
 

--- a/displacement_tracker/h_merge_geojsons.py
+++ b/displacement_tracker/h_merge_geojsons.py
@@ -28,6 +28,7 @@ from displacement_tracker.util.config import flow_option, load_flow_config
 from displacement_tracker.util.deduplication import merge_close_points_global
 from displacement_tracker.util.logging_config import setup_logging
 from displacement_tracker.util.thresholding import filter_points_by_adjusted_peak
+from displacement_tracker.util.zones import load_zone_geometry
 
 LOGGER = setup_logging("merge_geojsons")
 
@@ -114,37 +115,6 @@ def load_points_from_geojson(path: Path) -> list[tuple]:
         points.append([lat, lon, peak, adj_peak])
 
     return points
-
-
-def load_zone_geometry(zones_path: str | None, label: str):
-    """Load and unify polygon geometries from a shapefile or GeoPackage file."""
-    if not zones_path:
-        return None
-
-    path = Path(zones_path)
-    if not path.exists():
-        raise click.ClickException(f"{label} zones file not found: {path}")
-
-    try:
-        zones_gdf = gpd.read_file(path)
-    except Exception as exc:
-        raise click.ClickException(
-            f"Failed to read {label} zones file {path}: {exc}"
-        ) from exc
-
-    if zones_gdf.empty:
-        LOGGER.warning("%s zones file is empty: %s", label, path)
-        return None
-
-    if zones_gdf.crs is None:
-        LOGGER.warning("%s zones CRS missing, assuming EPSG:4326: %s", label, path)
-        zones_gdf = zones_gdf.set_crs("EPSG:4326")
-    else:
-        zones_gdf = zones_gdf.to_crs("EPSG:4326")
-
-    geom = zones_gdf.geometry.union_all()
-    LOGGER.info("Loaded %s zones from %s", label, path)
-    return geom
 
 
 def filter_points_by_zone(

--- a/displacement_tracker/h_merge_geojsons.py
+++ b/displacement_tracker/h_merge_geojsons.py
@@ -364,8 +364,9 @@ def merge_geojsons(
         raise click.ClickException(f"Input folder not found: {input_dir}")
 
     thresholds_data = load_thresholds(thresholds_config)
-    exclusion_geom = load_zone_geometry(exclusion_zones_gpkg, "exclusion")
-    inclusion_geom = load_zone_geometry(inclusion_zone, "inclusion")
+    # Merged prediction points are in lon/lat, so the zones are clipped there.
+    exclusion_geom = load_zone_geometry(exclusion_zones_gpkg, "exclusion", "EPSG:4326")
+    inclusion_geom = load_zone_geometry(inclusion_zone, "inclusion", "EPSG:4326")
 
     merge_kwargs = {
         "min_distance_m": min_distance_m,

--- a/displacement_tracker/pipelines/help.md
+++ b/displacement_tracker/pipelines/help.md
@@ -117,7 +117,7 @@ manually.
 |---|---|
 | `geotiff_dir` | Directory containing the input GeoTIFF satellite images. The download stage writes here; the scan stages read from here. |
 | `loading.files` | List of filename substrings. The download stage uses them as Google Drive search strings (empty = download nothing); the scan stages use them as filters (empty = scan **all** `.tif` files). |
-| `boundaries` | Gaza municipal boundaries shapefile; tiles outside it are skipped. |
+| `boundaries` | Gaza municipal boundaries shapefile. The training scan crops each source raster to it before tiling; the prediction flow tiles the whole raster and drops out-of-boundary points when the predictions are written. |
 | `prewar_gaza` | Pre-war reference raster. Each tile is paired with the matching pre-war crop; the model sees (current, pre-war, difference). |
 | `manifest_folder` | Where per-image tile manifests are written/read. **Runner-managed** → `manifests/`. |
 
@@ -128,7 +128,7 @@ manually.
 | `processing.core_metres` | Side length (m) of a tile's core area — the region whose predictions/labels count. |
 | `processing.margin_metres` | Extra context (m) around the core; tiles overlap by this margin. Also drives the prediction crop (`crop_pixels`) and NMS sigma. |
 | `processing.quality_thresholds.min_valid_fraction` | Minimum non-black/NaN fraction for a tile to be kept (train: strict ~0.9; predict: loose ~0.1). |
-| `processing.max_workers`, `max_tasks_per_child`, `max_pool_restarts` | Scan parallelism (training scanner). |
+| `processing.max_workers`, `max_tasks_per_child`, `max_pool_restarts` | Worker pool for the prediction scan (`b2_image_scanner`), so they live under `predict:`. The training scan is serial and reads none of them. |
 | `processing.complete` | Filenames processed in full, ignoring quality gates. |
 
 ### Training pipeline
@@ -195,7 +195,7 @@ point and the tuned global threshold cannot be shadowed:
 | `tuning.metrics` | Metrics tracked during the scan (the evaluation metric is always included). |
 | `tuning.factor_min/max`, `cutoff_min/max` | Search bounds for `adjustment_factor` / `min_adj_peak`. |
 | `tuning.ridge_probes`, `xtol_factor`, `xtol_cutoff`, `refine_maxiter` | Search effort and precision of the ridge-aware optimizer. |
-| `tuning.exclusion_zones` | Optional gpkg; predictions are clipped to its union before the scan. |
+| `tuning.inclusion_zones` | Optional gpkg; predictions are clipped to its union before the scan, i.e. only points inside it are kept. Unrelated to `merge.exclusion_zones_gpkg`, which drops points *inside* its geometries. |
 | `tuning.input` | Merged raw predictions; defaults to `merge.output`. **Runner-managed** → `merged_raw/merged_raw.gpkg`. |
 | `tuning.out_dir`, `best_params` | Scan artifacts (search trace, summary, rasters) and the tuned-parameter YAML. **Runner-managed** → `tuning/`. |
 | `tuning.final_output` | Final tuned GeoPackage. **Runner-managed** → `merged/merged_tuned.gpkg`. |

--- a/displacement_tracker/pipelines/spec.py
+++ b/displacement_tracker/pipelines/spec.py
@@ -120,7 +120,14 @@ PREDICT = Pipeline(
             "Processing",
             help="Minimum non-black/NaN fraction for a tile to be kept.",
         ),
-        Param("processing.max_workers", "Scan workers", "int", "Processing"),
+        Param(
+            "processing.max_workers",
+            "Scan workers",
+            "int",
+            "Processing",
+            help="Worker processes for the prediction scan "
+            "(0 = one per core, minus one).",
+        ),
         Param(
             "processing.max_tasks_per_child",
             "Tasks per worker",

--- a/displacement_tracker/pipelines/spec.py
+++ b/displacement_tracker/pipelines/spec.py
@@ -120,6 +120,22 @@ PREDICT = Pipeline(
             "Processing",
             help="Minimum non-black/NaN fraction for a tile to be kept.",
         ),
+        Param("processing.max_workers", "Scan workers", "int", "Processing"),
+        Param(
+            "processing.max_tasks_per_child",
+            "Tasks per worker",
+            "int",
+            "Processing",
+            help="Recycle a scan worker after this many tiles (0 = never).",
+        ),
+        Param(
+            "processing.max_pool_restarts",
+            "Max pool restarts",
+            "int",
+            "Processing",
+            help="How often the scan worker pool may be rebuilt after a "
+            "crash before the scan gives up.",
+        ),
         Param("prediction.batch_size", "Batch size", "int", "Prediction"),
         Param("prediction.num_workers", "Data-loader workers", "int", "Prediction"),
         Param(
@@ -233,7 +249,6 @@ TRAIN = Pipeline(
         Param("prewar_gaza", "Pre-war reference raster", "path", "Inputs"),
         Param("processing.core_metres", "Tile core size (m)", "int", "Processing"),
         Param("processing.margin_metres", "Tile margin (m)", "int", "Processing"),
-        Param("processing.max_workers", "Scan workers", "int", "Processing"),
         Param(
             "processing.quality_thresholds.min_valid_fraction",
             "Min valid fraction",
@@ -384,12 +399,13 @@ TUNE = Pipeline(
             help="Max Nelder-Mead iterations for the 2-D refinement (0 disables).",
         ),
         Param(
-            "tuning.exclusion_zones",
-            "Scan clip zones",
+            "tuning.inclusion_zones",
+            "Scan inclusion zones",
             "path",
             "Tuning",
             optional=True,
-            help="Optional gpkg; predictions are clipped to its union before the scan.",
+            help="Optional gpkg; predictions are clipped to its union before "
+            "the scan, i.e. only points inside it are kept.",
         ),
         Param("merge.min_distance_m", "Merge distance (m)", "float", "Merge"),
         Param("merge.agreement", "Min cluster size", "int", "Merge"),
@@ -437,7 +453,7 @@ TUNE = Pipeline(
             "xtol_factor": 1.0e-3,
             "xtol_cutoff": 1.0e-6,
             "refine_maxiter": 60,
-            "exclusion_zones": None,
+            "inclusion_zones": None,
         },
     },
 )

--- a/displacement_tracker/util/zones.py
+++ b/displacement_tracker/util/zones.py
@@ -1,0 +1,58 @@
+"""Loading polygon zone files used to include or exclude predictions.
+
+Three stages clip predictions against a zone file: the merge stage drops
+points inside its exclusion zones and outside its inclusion zone, and the two
+validation stages keep only the predictions inside their inclusion zones.
+They all need the same thing — one unified geometry, in the CRS of whatever
+they are about to clip — so they share this loader rather than each rolling
+its own ``read_file(...).geometry.union_all()``.
+
+The ``crs`` argument is what makes that sharing safe. A bare shapely geometry
+carries no CRS, and ``GeoDataFrame.clip()`` only validates CRS when the mask
+is itself a GeoDataFrame/GeoSeries, so an unreprojected mask clips silently in
+whatever space the file happened to be stored in.
+"""
+
+from pathlib import Path
+
+import click
+import geopandas as gpd
+
+from displacement_tracker.util.logging_config import setup_logging
+
+LOGGER = setup_logging(__name__)
+
+
+def load_zone_geometry(zones_path: str | None, label: str, crs="EPSG:4326"):
+    """Load and unify polygon geometries from a shapefile or GeoPackage file.
+
+    Returns a single geometry in ``crs``, or None when no path is given or the
+    file holds no features. ``label`` names the zones in log and error
+    messages ("exclusion", "inclusion").
+    """
+    if not zones_path:
+        return None
+
+    path = Path(zones_path)
+    if not path.exists():
+        raise click.ClickException(f"{label} zones file not found: {path}")
+
+    try:
+        zones_gdf = gpd.read_file(path)
+    except Exception as exc:
+        raise click.ClickException(
+            f"Failed to read {label} zones file {path}: {exc}"
+        ) from exc
+
+    if zones_gdf.empty:
+        LOGGER.warning("%s zones file is empty: %s", label, path)
+        return None
+
+    if zones_gdf.crs is None:
+        LOGGER.warning("%s zones CRS missing, assuming EPSG:4326: %s", label, path)
+        zones_gdf = zones_gdf.set_crs("EPSG:4326")
+    zones_gdf = zones_gdf.to_crs(crs)
+
+    geom = zones_gdf.geometry.union_all()
+    LOGGER.info("Loaded %s zones from %s", label, path)
+    return geom

--- a/displacement_tracker/util/zones.py
+++ b/displacement_tracker/util/zones.py
@@ -23,17 +23,21 @@ from displacement_tracker.util.logging_config import setup_logging
 LOGGER = setup_logging("zones")
 
 
-def load_zone_geometry(zones_path: str | None, label: str, crs: str):
+def load_zone_geometry(zones_path: str | None, label: str, crs):
     """Load and unify polygon geometries from a shapefile or GeoPackage file.
 
     Returns a single geometry in ``crs``, or None when no path is given or the
     file holds no features. ``label`` names the zones in log and error
     messages ("exclusion", "inclusion").
 
-    ``crs`` is deliberately required rather than defaulted: a caller that
-    clips in a projected CRS and forgets it would get a silent geographic
-    geometry and a mask that selects nothing, which is the exact failure this
-    parameter exists to prevent.
+    ``crs`` is anything ``GeoDataFrame.to_crs`` accepts — the merge stage
+    passes the string ``"EPSG:4326"``, the validation stages pass a
+    ``rasterio.crs.CRS`` straight off the open master grid — so it is left
+    unannotated, as every other CRS parameter in this codebase is. It is
+    deliberately required rather than defaulted: a caller that clips in a
+    projected CRS and forgets it would get a silent geographic geometry and a
+    mask that selects nothing, which is the exact failure this parameter
+    exists to prevent.
     """
     if not zones_path:
         return None

--- a/displacement_tracker/util/zones.py
+++ b/displacement_tracker/util/zones.py
@@ -20,15 +20,20 @@ import geopandas as gpd
 
 from displacement_tracker.util.logging_config import setup_logging
 
-LOGGER = setup_logging(__name__)
+LOGGER = setup_logging("zones")
 
 
-def load_zone_geometry(zones_path: str | None, label: str, crs="EPSG:4326"):
+def load_zone_geometry(zones_path: str | None, label: str, crs: str):
     """Load and unify polygon geometries from a shapefile or GeoPackage file.
 
     Returns a single geometry in ``crs``, or None when no path is given or the
     file holds no features. ``label`` names the zones in log and error
     messages ("exclusion", "inclusion").
+
+    ``crs`` is deliberately required rather than defaulted: a caller that
+    clips in a projected CRS and forgets it would get a silent geographic
+    geometry and a mask that selects nothing, which is the exact failure this
+    parameter exists to prevent.
     """
     if not zones_path:
         return None

--- a/tests/test_merge_geojsons.py
+++ b/tests/test_merge_geojsons.py
@@ -15,7 +15,6 @@ from displacement_tracker.h_merge_geojsons import (
     list_geojson_files,
     load_points_from_geojson,
     load_thresholds,
-    load_zone_geometry,
     merge_geojsons,
     merge_kwargs_from_config,
     parse_compact_date,
@@ -260,16 +259,6 @@ def test_filter_points_by_zone_none_zone_is_identity():
     # Then: the input list is returned unchanged regardless of keep_inside
     assert kept_inside == pts
     assert kept_outside == pts
-
-
-def test_load_zone_geometry_missing_file_raises():
-    # Given: a zones path that does not exist, labelled "exclusion"
-    missing = "/definitely/not/here.gpkg"
-
-    # When: load_zone_geometry tries to load it
-    # Then: a ClickException naming the missing exclusion zones file is raised
-    with pytest.raises(click.ClickException, match="exclusion zones file not found"):
-        load_zone_geometry(missing, "exclusion")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_scan_validation.py
+++ b/tests/test_scan_validation.py
@@ -45,7 +45,7 @@ def _settings(**overrides) -> ScanSettings:
         "xtol_factor": 1e-3,
         "xtol_cutoff": 1e-6,
         "refine_maxiter": 60,
-        "exclusion_zones": None,
+        "inclusion_zones": None,
     }
     base.update(overrides)
     return ScanSettings(**base)
@@ -177,7 +177,7 @@ def test_scan_settings_defaults_and_merge_output_fallback():
     assert s.xtol_factor == pytest.approx(1e-3)
     assert s.xtol_cutoff == pytest.approx(1e-6)
     assert s.refine_maxiter == 60
-    assert s.exclusion_zones is None
+    assert s.inclusion_zones is None
     assert s.pred_folder is None
 
 
@@ -202,6 +202,61 @@ def test_scan_settings_explicit_input_wins_and_pred_folder_from_merge():
     assert s.input_path == "explicit.gpkg"
     assert s.pred_folder == "preds"
     assert s.best_params_path == os.path.join("custom_out", "best_params.yaml")
+
+
+def test_scan_settings_carries_inclusion_zones():
+    # Given: a config setting the clip zones under the current key
+    params = {
+        "tuning": {
+            "input": "m.gpkg",
+            "master_grid": "g.tif",
+            "reference": "r.geojson",
+            "inclusion_zones": "zones.gpkg",
+        }
+    }
+
+    # When: ScanSettings.from_config resolves it
+    s = ScanSettings.from_config(params)
+
+    # Then: the path reaches the settings unchanged
+    assert s.inclusion_zones == "zones.gpkg"
+
+
+def test_scan_settings_legacy_exclusion_zones_key_raises():
+    # Given: a config still using the pre-rename tuning.exclusion_zones key,
+    #        whose name inverted what the clip actually does
+    params = {
+        "tuning": {
+            "input": "m.gpkg",
+            "master_grid": "g.tif",
+            "reference": "r.geojson",
+            "exclusion_zones": "zones.gpkg",
+        }
+    }
+
+    # When: ScanSettings.from_config resolves it
+    # Then: it fails loudly rather than silently ignoring the clip, and the
+    #       message names the key the user has to write instead
+    with pytest.raises(click.ClickException, match="tuning.inclusion_zones"):
+        ScanSettings.from_config(params)
+
+
+def test_scan_settings_legacy_exclusion_zones_key_raises_even_when_null():
+    # Given: the legacy key present but null — the shipped config's own value,
+    #        so a presence check is the only thing that catches a stale config
+    params = {
+        "tuning": {
+            "input": "m.gpkg",
+            "master_grid": "g.tif",
+            "reference": "r.geojson",
+            "exclusion_zones": None,
+        }
+    }
+
+    # When: ScanSettings.from_config resolves it
+    # Then: it still raises; a truthiness check here would pass a stale config
+    with pytest.raises(click.ClickException, match="tuning.inclusion_zones"):
+        ScanSettings.from_config(params)
 
 
 def test_scan_settings_missing_input_raises():

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -31,8 +31,8 @@ def test_no_path_returns_none():
     # Given: no zones configured -- the shipped default for every zone key
     # When: the loader runs on None and on the empty string
     # Then: both mean "no clipping", not "clip to nothing"
-    assert load_zone_geometry(None, "inclusion") is None
-    assert load_zone_geometry("", "inclusion") is None
+    assert load_zone_geometry(None, "inclusion", GRID_CRS) is None
+    assert load_zone_geometry("", "inclusion", GRID_CRS) is None
 
 
 def test_missing_file_raises_naming_the_label(tmp_path):
@@ -42,7 +42,7 @@ def test_missing_file_raises_naming_the_label(tmp_path):
     # When: the loader tries to load it
     # Then: a ClickException names the missing exclusion zones file
     with pytest.raises(click.ClickException, match="exclusion zones file not found"):
-        load_zone_geometry(missing, "exclusion")
+        load_zone_geometry(missing, "exclusion", GRID_CRS)
 
 
 def test_empty_file_returns_none(tmp_path):
@@ -53,7 +53,7 @@ def test_empty_file_returns_none(tmp_path):
     # When: the loader runs
     # Then: it degrades to "no clipping" rather than to an empty mask, which
     #       would silently discard every prediction
-    assert load_zone_geometry(str(path), "inclusion") is None
+    assert load_zone_geometry(str(path), "inclusion", GRID_CRS) is None
 
 
 def test_geometry_is_reprojected_to_the_requested_crs(tmp_path):
@@ -73,15 +73,15 @@ def test_geometry_is_reprojected_to_the_requested_crs(tmp_path):
     assert len(preds.clip(geom)) == 2
 
 
-def test_default_crs_is_wgs84_for_the_merge_stage(tmp_path):
-    # Given: the same zone file, in a projected CRS this time
+def test_reprojects_a_projected_file_to_wgs84(tmp_path):
+    # Given: a zone file stored in the projected grid CRS this time
     points = [Point(636000, 3475000), Point(636500, 3475500)]
     path = tmp_path / "zones_utm.gpkg"
     _write_zone_around(path, points, GRID_CRS, buffer_deg=1000)
 
-    # When: the loader runs without a crs argument, as the merge stage calls
-    #       it -- merged predictions are in lon/lat
-    geom = load_zone_geometry(str(path), "exclusion")
+    # When: EPSG:4326 is requested, as the merge stage does -- merged
+    #       prediction points are in lon/lat
+    geom = load_zone_geometry(str(path), "exclusion", FILE_CRS)
 
     # Then: the geometry comes back in EPSG:4326. Gaza sits near 34.4E/31.4N,
     #       so degrees and UTM metres are unmistakable from the bounds.

--- a/tests/test_zones.py
+++ b/tests/test_zones.py
@@ -1,0 +1,112 @@
+"""Unit tests for displacement_tracker/util/zones.py.
+
+Covers the zone-file loader shared by the merge and validation stages: the
+error and empty-file paths, and the CRS handling that decides whether a clip
+against the returned geometry is geometrically meaningful.
+"""
+
+import click
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from displacement_tracker.util.zones import load_zone_geometry
+
+# A UTM zone (36N) covering Gaza, and the geographic CRS zone files most
+# commonly arrive in. The two disagree by hundreds of thousands of units, so
+# a mask in the wrong one selects nothing rather than selecting sloppily.
+GRID_CRS = "EPSG:32636"
+FILE_CRS = "EPSG:4326"
+
+
+def _write_zone_around(path, points, crs, buffer_deg=0.01):
+    """Write a zone file in `crs` covering `points` (given in GRID_CRS)."""
+    covered = gpd.GeoSeries(points, crs=GRID_CRS).to_crs(crs)
+    gdf = gpd.GeoDataFrame(geometry=[covered.union_all().buffer(buffer_deg)], crs=crs)
+    gdf.to_file(path)
+    return gdf
+
+
+def test_no_path_returns_none():
+    # Given: no zones configured -- the shipped default for every zone key
+    # When: the loader runs on None and on the empty string
+    # Then: both mean "no clipping", not "clip to nothing"
+    assert load_zone_geometry(None, "inclusion") is None
+    assert load_zone_geometry("", "inclusion") is None
+
+
+def test_missing_file_raises_naming_the_label(tmp_path):
+    # Given: a zones path that does not exist, labelled "exclusion"
+    missing = str(tmp_path / "not_here.gpkg")
+
+    # When: the loader tries to load it
+    # Then: a ClickException names the missing exclusion zones file
+    with pytest.raises(click.ClickException, match="exclusion zones file not found"):
+        load_zone_geometry(missing, "exclusion")
+
+
+def test_empty_file_returns_none(tmp_path):
+    # Given: a readable zone file holding no features
+    path = tmp_path / "empty.gpkg"
+    gpd.GeoDataFrame(geometry=[], crs=FILE_CRS).to_file(path)
+
+    # When: the loader runs
+    # Then: it degrades to "no clipping" rather than to an empty mask, which
+    #       would silently discard every prediction
+    assert load_zone_geometry(str(path), "inclusion") is None
+
+
+def test_geometry_is_reprojected_to_the_requested_crs(tmp_path):
+    # Given: two points on the master grid, and a zone file covering both but
+    #        stored in EPSG:4326 as zone files usually are
+    points = [Point(636000, 3475000), Point(636500, 3475500)]
+    path = tmp_path / "zones.gpkg"
+    _write_zone_around(path, points, FILE_CRS)
+    preds = gpd.GeoDataFrame(geometry=points, crs=GRID_CRS)
+
+    # When: the zones are loaded for use against grid-CRS predictions
+    geom = load_zone_geometry(str(path), "inclusion", GRID_CRS)
+
+    # Then: clipping keeps both points. The mask is a bare shapely geometry,
+    #       which .clip() cannot CRS-check, so an unreprojected mask would
+    #       silently keep zero -- the whole reason crs is a parameter.
+    assert len(preds.clip(geom)) == 2
+
+
+def test_default_crs_is_wgs84_for_the_merge_stage(tmp_path):
+    # Given: the same zone file, in a projected CRS this time
+    points = [Point(636000, 3475000), Point(636500, 3475500)]
+    path = tmp_path / "zones_utm.gpkg"
+    _write_zone_around(path, points, GRID_CRS, buffer_deg=1000)
+
+    # When: the loader runs without a crs argument, as the merge stage calls
+    #       it -- merged predictions are in lon/lat
+    geom = load_zone_geometry(str(path), "exclusion")
+
+    # Then: the geometry comes back in EPSG:4326. Gaza sits near 34.4E/31.4N,
+    #       so degrees and UTM metres are unmistakable from the bounds.
+    minx, miny, maxx, maxy = geom.bounds
+    assert 34 < minx < 35 and 34 < maxx < 35
+    assert 31 < miny < 32 and 31 < maxy < 32
+
+
+def test_crs_less_file_is_assumed_wgs84(tmp_path):
+    # Given: a shapefile holding lon/lat coordinates whose .prj sidecar is
+    #        missing, so it genuinely reads back with crs=None. (A GPKG
+    #        cannot stand in here -- it records the CRS internally, so the
+    #        assumption branch would never be reached and this test could
+    #        not fail.)
+    path = tmp_path / "no_crs.shp"
+    gpd.GeoDataFrame(geometry=[Point(34.45, 31.41).buffer(0.01)], crs=FILE_CRS).to_file(
+        path
+    )
+    (tmp_path / "no_crs.prj").unlink()
+    assert gpd.read_file(path).crs is None
+
+    # When: the loader is asked for it on the master grid's CRS
+    geom = load_zone_geometry(str(path), "inclusion", GRID_CRS)
+
+    # Then: the coordinates are assumed to be WGS84 and reprojected, landing
+    #       in the hundreds of thousands of metres rather than staying near 34
+    minx, _, _, _ = geom.bounds
+    assert minx > 100_000


### PR DESCRIPTION
PR 3 of the master-grid tiling migration (`docs/master-grid-tiling-migration.md`, currently on `claude/tiling-master-grid-refactor-fp0v42`), following #40. Two config keys were in the wrong section and one was named the inverse of what it does. Review then turned up a real geometry bug on the lines the rename touches, so that is fixed here too.

## Pool keys move `train:` → `predict:`

`processing.max_workers`, `max_tasks_per_child` and `max_pool_restarts` are read only by `b2_image_scanner` (`:348-353`). `b1`'s CLI reads none of them (`b1:349-361`), so sitting under `train:` they were inert — and `b2`, which resolves the `predict` section, always ran on its code-side defaults (`cpu_count()-1`, 32, 3) rather than the shipped 8 / 16 / 10.

`Param("processing.max_workers", …)` also leaves the TRAIN param list. `app.py:416` renders every Param unconditionally, so leaving it there once the key is gone from the train section would re-inject `processing.max_workers: 0` into every train run.

All three keys are added to the PREDICT param list instead, so the UI knob follows the config rather than disappearing. That is a small extension of the plan, which only said to drop the TRAIN Param — flagging it rather than burying it. Each documents its sentinel, including `max_workers`, where `0` means "one per core, minus one" (`b2:202`) and is also exactly what the widget prefills for an absent key.

## `tuning.exclusion_zones` → `tuning.inclusion_zones`

The old name said the opposite of the behaviour. g1 does `pred_gdf.clip(union)` — which **keeps** points inside — as does g2, whereas `merge.exclusion_zones_gpkg` **drops** points inside. Two knobs, opposite semantics, near-identical names.

Renamed at all three sites the tune flow resolves through, since missing any one of them breaks tune:

| Site | Why it matters |
|---|---|
| `config.yaml:197` | The shipped value. |
| the `Param` in `spec.py` | What the UI writes. |
| TUNE's `extra_defaults` in `spec.py` | `runner.py:131-136` deep-merges it into **every** prepared tune config, so a stale entry here reintroduces the old key behind the user's back. |

Plus the `ScanSettings` field and g2's `--exclusion-zones` flag. `merge.exclusion_zones_gpkg` and `merge.inclusion_zone` are correctly named and are untouched.

## Failing loudly on the old key

A config still carrying `tuning.exclusion_zones` now hard-errors out of `ScanSettings.from_config` with a message naming the new key, instead of silently dropping the clip and scanning the full prediction set.

The check is on key **presence**, not truthiness. The shipped value is `null`, so a truthiness check would wave a stale config straight through. The cost is that `runner.py` has been stamping `exclusion_zones: null` into every tune run directory, so archived run configs now fail on re-run over a value that was always a no-op — the message therefore names the remedy for both cases: *"Rename the key in your config, or delete it if it is unset — archived run configs carry it as null."*

g2's flag rename is handled by Click, which answers `No such option: --exclusion-zones Did you mean --inclusion-zones?`.

## Docs the UI renders live

`help.md` is rendered by `app.py:385`, so these are user-facing surfaces, not comments:

* The pool-key row read *"Scan parallelism (training scanner)"* — the exact inversion of where the keys are read. Now names `b2` and says the training scan is serial.
* The `tuning.exclusion_zones` row is renamed, and now contrasts itself with `merge.exclusion_zones_gpkg` so the two knobs cannot be confused again.
* `config.yaml:17` **and** `help.md`'s `boundaries` row both claimed tiles outside the boundaries are *"skipped by every scan stage"*. Only `b1` skips anything, and it does so by cropping the source raster before tiling; predict tiles the whole raster and drops out-of-boundary points at emission (`e_predict_json.py:335-346`). Both are now worded per-stage. The plan assigned only `config.yaml:17` to this PR; fixing the identical claim in both places now was a deliberate call, since leaving one half wrong in the live help had no upside.

## Zone clips now align CRS (from review)

Both clip sites passed `.clip()` a bare shapely geometry read straight from the zone file. GeoPandas only CRS-checks a mask that is itself a GeoDataFrame/GeoSeries, so a bare geometry clips in whatever space the file happened to be stored in — silently. Predictions are reprojected onto the master grid first, so the two disagreed whenever the zone file was not already in the grid CRS: zones in EPSG:4326 against a UTM grid clip to nothing (`No predictions left to scan`, cause unstated), and zones in a different projected CRS clip to a plausible-looking wrong subset.

Reproduced before fixing — a zone covering two grid-CRS points but stored in 4326 keeps **0 of 2** through the old path, **2 of 2** through the new one.

`h_merge_geojsons.load_zone_geometry` was already this function (missing file, unreadable file, empty file, absent CRS, reprojection) except that it hardcoded `to_crs("EPSG:4326")`. It gains a **required** `crs` parameter and moves to `util/zones.py`, which is where this repo puts logic shared across stages (`AGENTS.md:13`); three stages now call it. Merge passes `"EPSG:4326"` explicitly, so its behaviour is unchanged and its call site now says why that CRS is the right one there. The CRS-less branch still assumes 4326 before reprojecting, rather than assuming whatever the caller asked for — the file's coordinates are what they are. That removes both bespoke `read_file(...).geometry.union_all()` copies, which this PR had otherwise been renaming in place. g2's read moves inside the `rasterio.open` block, since the grid CRS is not known before it.

This is pre-existing behaviour, and fixing it widens the PR past the plan's PR 3. Two things made it the right call rather than a follow-up: the bug lives on the exact lines being rewritten, and `to_crs` to a frame's existing CRS returns coordinate-identical geometry (checked with `equals_exact(..., 0.0)`), so the plan's byte-identical g1 gate still holds for every zone file that works today. The only outputs that change are the ones that were already wrong.

## Behaviour notes for the run log

Two things change that no test can surface as a failure, both raised in review:

* **Predict scan worker count.** It previously ran on `cpu_count()-1` and now runs on the shipped `8`. On a large box that is a throughput reduction, on a small one a memory saving. It is the intended effect of the key move, but it is a real runtime change on every prediction run — worth eyeballing the `b2` log line on the first real scan.
* **An empty inclusion-zone file now widens instead of erroring.** It used to reach `union_all()` on an empty frame, clip to nothing, and raise `No predictions left to scan`. Going through `load_zone_geometry` it warns and returns `None`, so the scan runs unclipped over the full prediction set. For *inclusion* semantics that is the counter-intuitive direction — the literal reading of an empty inclusion file is "include nothing". It is kept deliberately: `merge.inclusion_zone` has always behaved exactly this way, so this makes the three stages agree rather than diverge, and the alternative is an include-vs-exclude mode flag on a function whose appeal is having none. The warning names the file.

## Tests

The plan gives PR 3 no Tests section, but the hard error is new deterministic behavior with a wrong-answer mode, so it gets coverage under `docs/test-patterns.md`.

* `tests/test_scan_validation.py`: the `ScanSettings` field rename, plus the new key reaching settings intact and the legacy key raising **both** when set and when null. The null case pins presence-over-truthiness; drop the presence check and it is the only test that fails.
* `tests/test_zones.py` (new): the loader at its new home — no-path, missing file, empty file, reprojection to a requested CRS, the projected → geographic direction merge depends on, and the CRS-less assumption. That last one uses a shapefile with its `.prj` removed, because a GPKG records its CRS internally and would never reach the branch; the test asserts `crs is None` first so it cannot silently go vacuous. Both CRS tests were mutation-checked — dropping `to_crs` fails three of them, and assuming the target CRS instead of 4326 fails the CRS-less one. The single zone test in `test_merge_geojsons.py` moves across with its subject.

## Follow-ups this PR deliberately does not take

Creating a canonical home for "read a polygon file, validate it, land it in a known CRS" makes two more copies of the pattern visible. Neither is on a line this PR modifies, so neither is in scope here — recorded so they are not rediscovered. They belong in `docs/master-grid-tiling-migration.md`, which is not on `Karim` yet, so they are noted here in the meantime:

* `i_zonal_point_sums.load_gdf:35-52` — the same read → missing → unreadable → CRS-fallback sequence, in a stage module. It differs only in its tail: it returns the frame (it needs per-zone attributes, not a union) and hard-errors on empty. A `load_zone_frame()` in `util/zones.py` that both call, with the empty-file policy left at the two call sites where it genuinely differs, is the shape. PR 13 is already in the validation stages.
* `e_predict_json.save_geojson:344-349` — `read_file` → `to_crs("EPSG:4326")` → `union_all()` on the boundaries shapefile. Not a drop-in: `gaza_union.contains(pt)` needs an answer for the `None` return. PR 10 is already in that boundary filter.

## Verification

Run against all three CI gates:

* `ruff check .` and `ruff format --check .` → clean.
* `poetry install --only test --no-root` + `poetry run python -m pytest tests/ -q` → **246 passed**.
* `pipeline-run train|predict|tune --dry-run` all resolve. The resolved **predict** config carries the three pool keys; the resolved **train** config carries none of them; the resolved tune config carries `tuning.inclusion_zones` and, separately, `merge.exclusion_zones_gpkg`.
* A config with `tuning.exclusion_zones` exits 1 with the rename message; `--exclusion-zones` on g2 exits with Click's did-you-mean.

Needs the data share and is **not** run here — worth doing before merge:

* A `b2` scan whose log line shows the configured `max_workers` (the one place the pool-key move is observable at runtime).
* A g1 run with `inclusion_zones` set, reproducing the prior output byte-identically.

## Note on sequencing

PR 2 of the plan is #55, still open. PR 3 does not depend on it — the plan lists no dependencies for either — but PR 6 depends on both. #55 also touches `g2_validate_geojson.py` (making `--reference-type` lazy) where this PR renames a different option on the same command, so whichever merges second should be a clean textual merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTYdqvR673Fw1pfHhTGiiZ