### PR TITLE
Add model reference parsing

### DIFF
--- a/displacement_tracker/util/model_ref.py
+++ b/displacement_tracker/util/model_ref.py
@@ -1,0 +1,125 @@
+"""Parse a model reference into the checkpoint it names.
+
+A model reference is either a filesystem path — the historic behaviour, kept
+for local development checkpoints — or a release on the Hugging Face Hub::
+
+    hf:<owner>/<name>@<40-char-commit-sha>#<filename>
+    https://huggingface.co/<owner>/<name>/blob/<sha>/<filename>
+
+Parsing is separated from resolving them because it is a total, offline
+function: any string is either a Hub reference, a path, or a syntax error,
+and deciding which needs no filesystem and no network.
+
+Only a commit SHA can pin a release — branches and tags move — but a
+reference is parsed whether or not it names one, so that resolution can
+report precisely which part is missing rather than failing on the syntax.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+import click
+
+HF_SCHEME = "hf:"
+HF_HOSTS = frozenset({"huggingface.co", "www.huggingface.co"})
+
+# A Hub commit SHA: 40 lowercase hex characters. Nothing else pins.
+_COMMIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+_REPO_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+_SYNTAX = "hf:<owner>/<name>@<40-char-commit-sha>#<filename>"
+
+
+class ModelRefError(click.ClickException):
+    """A model reference could not be parsed or resolved.
+
+    Subclasses ClickException so stage CLIs print the message rather than a
+    traceback; the message is the user-facing explanation and always carries
+    the next action.
+    """
+
+
+@dataclass(frozen=True)
+class HubRef:
+    """A parsed Hugging Face Hub reference.
+
+    ``revision`` and ``filename`` are optional so that a partial reference
+    still parses, and whoever resolves it can say which part is missing.
+    """
+
+    repo_id: str
+    revision: str | None = None
+    filename: str | None = None
+
+    def __str__(self) -> str:
+        text = f"{HF_SCHEME}{self.repo_id}"
+        if self.revision:
+            text += f"@{self.revision}"
+        if self.filename:
+            text += f"#{self.filename}"
+        return text
+
+
+def parse_model_ref(ref: str | Path) -> HubRef | Path:
+    """Parse ``ref`` into a :class:`HubRef` or a local :class:`Path`.
+
+    Performs no network or filesystem access. Only the ``hf:`` scheme and
+    Hugging Face URLs are treated as Hub references, so a local path is never
+    mistaken for one — including paths containing ``@`` or ``#``.
+    """
+    text = str(ref).strip()
+    if not text:
+        raise ModelRefError(
+            f"Model reference is empty; expected a checkpoint path or {_SYNTAX}."
+        )
+    if text.startswith(HF_SCHEME):
+        return _parse_hub_ref(text[len(HF_SCHEME) :])
+    if _is_hub_url(text):
+        return _parse_hub_url(text)
+    return Path(text).expanduser()
+
+
+def _is_hub_url(text: str) -> bool:
+    if not text.startswith(("http://", "https://")):
+        return False
+    return urlparse(text).netloc.lower() in HF_HOSTS
+
+
+def _parse_hub_ref(body: str) -> HubRef:
+    body, _, filename = body.partition("#")
+    repo_id, _, revision = body.partition("@")
+    return _hub_ref(repo_id, revision, filename)
+
+
+def _parse_hub_url(text: str) -> HubRef:
+    parts = [part for part in urlparse(text).path.split("/") if part]
+    if len(parts) < 2:
+        raise ModelRefError(
+            f"Not a Hugging Face model URL: {text}. Expected "
+            f"https://huggingface.co/<owner>/<name>/blob/<sha>/<filename>, or {_SYNTAX}."
+        )
+    repo_id = "/".join(parts[:2])
+    revision = filename = ""
+    # .../blob/<rev>/<path> and .../resolve/<rev>/<path> both appear in URLs
+    # copied out of the Hub UI.
+    if len(parts) > 3 and parts[2] in ("blob", "resolve"):
+        revision = parts[3]
+        filename = "/".join(parts[4:])
+    return _hub_ref(repo_id, revision, filename)
+
+
+def _hub_ref(repo_id: str, revision: str, filename: str) -> HubRef:
+    if not _REPO_ID.match(repo_id):
+        raise ModelRefError(
+            f"'{repo_id}' is not a Hugging Face repo id; expected <owner>/<name> in {_SYNTAX}."
+        )
+    revision = revision.strip()
+    # Hub SHAs are lowercase; accept a pasted uppercase one rather than
+    # mistaking it for a branch name.
+    if re.fullmatch(r"[0-9a-fA-F]{40}", revision):
+        revision = revision.lower()
+    return HubRef(repo_id, revision or None, filename.strip() or None)

--- a/tests/test_config_model_ref.py
+++ b/tests/test_config_model_ref.py
@@ -1,0 +1,65 @@
+"""Tests that a Hugging Face model reference survives config loading.
+
+``config.yaml`` goes through ``${ENV}`` substitution and shared/per-flow
+merging before any stage sees it. Neither step may mangle an ``hf:``
+reference — the ``@``, the ``#`` and the 40-character commit SHA all have to
+arrive intact, or a pinned model silently stops being pinned.
+"""
+
+import pytest
+
+from displacement_tracker.util.config import load_flow_config
+from displacement_tracker.util.model_ref import HubRef, parse_model_ref
+
+REPO = "realgoodresearch/tentnetfa"
+SHA = "a" * 40
+FILE = "best_model.safetensors"
+REF = f"hf:{REPO}@{SHA}#{FILE}"
+
+CONFIG = f"""
+shared:
+  boundaries: gaza_boundaries/GazaStrip_MunicipalBoundaries.shp
+train:
+  training:
+    checkpoint: {REF}
+predict:
+  prediction:
+    model: {REF}
+"""
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    """A sectioned config pinning a model in both flows, written unquoted."""
+    path = tmp_path / "config.yaml"
+    path.write_text(CONFIG, encoding="utf-8")
+    return str(path)
+
+
+def test_a_hub_reference_survives_substitution_and_merging(config_path):
+    # Given: a sectioned config pinning a model in the predict and train
+    #        flows, written unquoted as a user would write it
+
+    # When: the predict flow is resolved
+    predict = load_flow_config(config_path, "predict")
+
+    # Then: the reference arrives byte-for-byte — the bare "#" did not start
+    #       a YAML comment and the "@" was not reinterpreted
+    assert predict["prediction"]["model"] == REF
+
+    # When: the train flow is resolved
+    train = load_flow_config(config_path, "train")
+
+    # Then: its own pinned checkpoint arrives intact too
+    assert train["training"]["checkpoint"] == REF
+
+
+def test_a_pinned_reference_from_a_config_parses_back(config_path):
+    # Given: a config whose predict flow pins a model
+    resolved = load_flow_config(config_path, "predict")
+
+    # When: the stored reference is parsed as the resolver would
+    ref = parse_model_ref(resolved["prediction"]["model"])
+
+    # Then: the round trip through YAML yields the same three parts
+    assert ref == HubRef(REPO, SHA, FILE)

--- a/tests/test_model_ref.py
+++ b/tests/test_model_ref.py
@@ -1,0 +1,153 @@
+"""Tests for displacement_tracker.util.model_ref: parsing a model reference
+into the Hub release or local checkpoint it names.
+
+Parsing needs no network and no filesystem, so nothing here is stubbed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from displacement_tracker.util.model_ref import (
+    HubRef,
+    ModelRefError,
+    parse_model_ref,
+)
+
+SHA = "a" * 40
+REPO = "realgoodresearch/tentnetfa"
+FILE = "best_model.safetensors"
+REF = f"hf:{REPO}@{SHA}#{FILE}"
+
+
+# ---------------------------------------------------------------------------
+# Hub references
+# ---------------------------------------------------------------------------
+
+
+def test_parses_a_fully_pinned_reference():
+    # Given: a reference naming a repo, a commit SHA and a file
+    # When: it is parsed
+    ref = parse_model_ref(REF)
+
+    # Then: all three parts are recovered, and it round-trips back to the
+    #       text a config would hold
+    assert ref == HubRef(REPO, SHA, FILE)
+    assert str(ref) == REF
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        (f"hf:{REPO}", HubRef(REPO, None, None)),
+        (f"hf:{REPO}@{SHA}", HubRef(REPO, SHA, None)),
+        (f"hf:{REPO}#{FILE}", HubRef(REPO, None, FILE)),
+        (f"hf:{REPO}@main#{FILE}", HubRef(REPO, "main", FILE)),
+        (f"  hf:{REPO}@{SHA}#{FILE}  ", HubRef(REPO, SHA, FILE)),
+    ],
+)
+def test_parses_references_with_parts_missing(text, expected):
+    # Given: a reference missing a revision, a file, or both
+    # When: it is parsed
+    # Then: the absent parts read as None rather than raising, so whoever
+    #       resolves it can report precisely which one is missing
+    assert parse_model_ref(text) == expected
+
+
+@pytest.mark.parametrize("kind", ["blob", "resolve"])
+def test_parses_urls_copied_from_the_hub_ui(kind):
+    # Given: a file URL of the kind the Hub UI offers, in either form
+    url = f"https://huggingface.co/{REPO}/{kind}/{SHA}/{FILE}"
+
+    # When: it is parsed
+    # Then: it yields the same reference as the compact hf: syntax
+    assert parse_model_ref(url) == HubRef(REPO, SHA, FILE)
+
+
+def test_parses_a_url_naming_only_the_repository():
+    # Given: a bare repository URL, with no revision or file
+    # When: it is parsed
+    # Then: the repo is recovered and the rest is left absent
+    assert parse_model_ref(f"https://huggingface.co/{REPO}") == HubRef(REPO, None, None)
+
+
+def test_parses_a_file_nested_in_a_subdirectory():
+    # Given: a URL whose file sits below the repository root
+    url = f"https://huggingface.co/{REPO}/blob/{SHA}/weights/{FILE}"
+
+    # When: it is parsed
+    # Then: the whole relative path is kept as the filename
+    assert parse_model_ref(url).filename == f"weights/{FILE}"
+
+
+def test_accepts_an_uppercase_sha():
+    # Given: a SHA pasted in uppercase
+    # When: the reference is parsed
+    ref = parse_model_ref(f"hf:{REPO}@{SHA.upper()}#{FILE}")
+
+    # Then: it is normalised to the Hub's lowercase form, so it still reads
+    #       as a commit rather than as a branch name
+    assert ref.revision == SHA
+
+
+# ---------------------------------------------------------------------------
+# Local paths
+# ---------------------------------------------------------------------------
+
+
+def test_local_checkpoint_paths_pass_through():
+    # Given: the kind of path config.yaml has always held
+    # When: it is parsed
+    # Then: it comes back as a plain path, with Hub handling out of the way
+    assert parse_model_ref("runs/20260511_104602/best_model.pth") == Path(
+        "runs/20260511_104602/best_model.pth"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["runs/v2@1/best_model.pth", "runs/v2#1/best_model.pth"],
+)
+def test_a_path_containing_reference_punctuation_is_still_a_path(path):
+    # Given: a local path whose directory name contains "@" or "#" — the
+    #        characters that delimit a Hub reference
+    # When: it is parsed
+    # Then: it is still a path; only the hf: scheme and Hub URLs are special
+    assert parse_model_ref(path) == Path(path)
+
+
+def test_home_relative_paths_are_expanded():
+    # Given: a path written relative to the home directory
+    # When: it is parsed
+    # Then: the tilde is expanded, so the file can actually be opened
+    assert parse_model_ref("~/runs/best_model.pth").is_absolute()
+
+
+# ---------------------------------------------------------------------------
+# Syntax errors
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_reference_is_rejected():
+    # Given: a config key left blank
+    # When: it is parsed
+    # Then: it raises rather than resolving to the current directory
+    with pytest.raises(ModelRefError, match="empty"):
+        parse_model_ref("   ")
+
+
+@pytest.mark.parametrize("bad", [f"hf:{REPO}/extra@{SHA}", "hf:nameonly", "hf:/name"])
+def test_malformed_repo_ids_are_rejected(bad):
+    # Given: an hf: reference whose repo id is not <owner>/<name>
+    # When: it is parsed
+    # Then: it raises naming the expected syntax
+    with pytest.raises(ModelRefError, match="repo id"):
+        parse_model_ref(bad)
+
+
+def test_a_hub_url_without_a_repository_name_is_rejected():
+    # Given: a Hub URL naming only an owner
+    # When: it is parsed
+    # Then: it raises rather than inventing a repository
+    with pytest.raises(ModelRefError, match="Hugging Face model URL"):
+        parse_model_ref("https://huggingface.co/owner")


### PR DESCRIPTION
**First of three stacked PRs.** Review this one first — it is self-contained and adds no dependencies.

- **#57 (this) — parsing.** Text → a Hub reference or a path. *343 lines, no new dependencies.*
- **#58 — local resolution.** Resolve a path to a verified file. *163 lines, no new dependencies.*
- **#52 — Hub fetching.** Download a pinned release. *943 lines, of which 227 is generated lockfile.*

## What

Adds `displacement_tracker/util/model_ref.py` with the parsing half of naming a model — turning a reference into the thing it names, without yet resolving it:

```
hf:<owner>/<name>@<40-char-commit-sha>#<filename>
https://huggingface.co/<owner>/<name>/blob/<sha>/<filename>
```

Anything that is not the `hf:` scheme or a Hugging Face URL stays a path, so existing configs keep working and a local path containing `@` or `#` is never mistaken for a Hub reference.

## Why

`prediction.model` currently points at `/home/karim/TentNetFA/runs/v2.0/best_model.pth`. Those weights exist on one machine, carry no version, are not checksummed, and nothing records which model produced a given output — a fresh clone cannot run inference, and a prediction cannot be traced back to specific weights.

## Why parsing is its own change

Parsing is a total, offline function: any string is a Hub reference, a path, or a syntax error, and deciding which needs no filesystem and no network. Splitting it keeps this change **free of new dependencies, of any lockfile churn, and of any test that stubs anything** — all of which belong to the Hub layer in #52.

A partial reference parses rather than failing, so that resolution can later report which part is missing: naming no revision is a different problem from naming a branch, and both differ from a typo in the repo id.

## Testing

22 tests covering both reference shapes, partial references, URL forms copied from the Hub UI, uppercase SHA normalisation, paths that contain reference punctuation, and the syntax errors. Nothing is stubbed; no network.

`ruff check .`, `ruff format --check .` and the full 260-test suite pass.